### PR TITLE
Add apis.json for docs synchronization reference

### DIFF
--- a/src/apis.json
+++ b/src/apis.json
@@ -1,7 +1,8 @@
 [
   {
     "name": "fs",
-    "description": "The fs or filesystem API allows you to create, read, and modify files on the repl's filesystem.","typeNames": ["WatchFileWatchers", "WatchTextFileWatchers"],
+    "description": "The fs or filesystem API allows you to create, read, and modify files on the repl's filesystem.",
+    "typeNames": ["WatchFileWatchers", "WatchTextFileWatchers"],
     "isActive": true
   },
   {


### PR DESCRIPTION
We need to have a json file where we specify what apis to expose to the documentation.  The schema for an api is as follows:

```typescript
{
    name: string;
    descriptiion: string;
    typeNames: Array<string>;
    isActive: boolean;
  }
```

if isActive is true, we will expose the documentation page for it.  If not, we'll show it as under contruction.