### PR TITLE
Add Data API to extensions repo

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## 0.29.0
+
+- Added the data module
+
 ## 0.28.2
 
  - Updated the `useWatchTextFile` React hook

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -3,6 +3,7 @@ import {
   useReplit,
   useWatchTextFile,
   useTheme,
+  useReplitEffect,
 } from "@replit/extensions/react";
 import { messages } from "@replit/extensions";
 import "./App.css";
@@ -23,6 +24,10 @@ export default function App() {
   const sendMessage = () => {
     messages.showNotice("THIS IS A TEST");
   };
+
+  useReplitEffect(async ({ data }) => {
+    console.log(await data.user.current());
+  }, []);
 
   const randomizeJson = async () => {
     try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/extensions",
-  "version": "0.28.2",
+  "version": "0.29.0",
   "description": "",
   "exports": {
     "./package.json": "./package.json",

--- a/src/api/data.ts
+++ b/src/api/data.ts
@@ -1,30 +1,36 @@
-import { UserDataInclusion } from "src/types";
+import {
+  JsonDataReponse,
+  ReplDataInclusion,
+  UserDataInclusion,
+} from "src/types";
 import { extensionPort } from "src/util/comlink";
 
 export const user = {
-  async current(args: UserDataInclusion) {
+  async current(args: UserDataInclusion): JsonDataReponse {
     return await extensionPort.currentUser(args);
   },
 
-  async byId(args: { id: string } & UserDataInclusion) {
+  async byId(args: { id: string } & UserDataInclusion): JsonDataReponse {
     return await extensionPort.userById(args);
   },
 
-  async byUsername(args: { username: string } & UserDataInclusion) {
+  async byUsername(
+    args: { username: string } & UserDataInclusion
+  ): JsonDataReponse {
     return await extensionPort.userByUsername(args);
   },
 };
 
 export const repl = {
-  async current(args: UserDataInclusion) {
+  async current(args: ReplDataInclusion): JsonDataReponse {
     return await extensionPort.currentRepl(args);
   },
 
-  async byId(args: { id: string } & UserDataInclusion) {
+  async byId(args: { id: string } & ReplDataInclusion): JsonDataReponse {
     return await extensionPort.replById(args);
   },
 
-  async byUrl(args: { url: string } & UserDataInclusion) {
+  async byUrl(args: { url: string } & ReplDataInclusion): JsonDataReponse {
     return await extensionPort.replByUrl(args);
   },
 };

--- a/src/api/data.ts
+++ b/src/api/data.ts
@@ -1,0 +1,30 @@
+import { UserDataInclusion } from "src/types";
+import { extensionPort } from "src/util/comlink";
+
+export const user = {
+  async current(args: UserDataInclusion) {
+    return await extensionPort.currentUser(args);
+  },
+
+  async byId(args: { id: string } & UserDataInclusion) {
+    return await extensionPort.userById(args);
+  },
+
+  async byUsername(args: { username: string } & UserDataInclusion) {
+    return await extensionPort.userByUsername(args);
+  },
+};
+
+export const repl = {
+  async current(args: UserDataInclusion) {
+    return await extensionPort.currentRepl(args);
+  },
+
+  async byId(args: { id: string } & UserDataInclusion) {
+    return await extensionPort.replById(args);
+  },
+
+  async byUrl(args: { url: string } & UserDataInclusion) {
+    return await extensionPort.replByUrl(args);
+  },
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,8 +3,9 @@ import * as replDb from "./replDb";
 import * as me from "./me";
 import * as theme from "./theme";
 import * as messages from "./messages";
+import * as data from "./data";
 
-export { fs, replDb, me, theme, messages };
+export { fs, replDb, me, theme, messages, data };
 
 // deprecate this after migrating existing extensions
 export * from "./fs";

--- a/src/apis.json
+++ b/src/apis.json
@@ -23,6 +23,12 @@
     "isActive": true
   },
   {
+    "name": "data",
+    "description": "The data API allows you to get information and metadata exposed from Replit's GraphQL API.",
+    "typeNames": ["UserDataInclusion", "ReplDataInclusion", "JsonDataResponse"],
+    "isActive": true
+  },
+  {
     "name": "rui",
     "description": "The RUI or Replit User Interface API lets you create with Replit's UI Components.",
     "typeNames": []

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -275,15 +275,6 @@ export type ExtensionPortAPI = {
   getCurrentTheme: () => Promise<Theme>;
   onThemeChange: (callback: (theme: Theme) => void) => Promise<() => void>;
 
-  // jets (will be deprecated)
-
-  // graphql
-  queryGraphql(args: { query: string; variables?: Record<string, any> }): any;
-  mutateGraphql(args: {
-    mutation: string;
-    variables?: Record<string, any>;
-  }): any;
-
   // eval
   eval(code: string): any;
 
@@ -295,7 +286,31 @@ export type ExtensionPortAPI = {
   showWarning: (text: string, length?: number) => string;
   hideMessage: (id: string) => void;
   hideAllMessages: () => void;
+
+  currentUser: (args: UserDataInclusion) => JsonDataReponse;
+  userById: (args: { id: string } & UserDataInclusion) => JsonDataReponse;
+  userByUsername: (
+    args: { username: string } & UserDataInclusion
+  ) => JsonDataReponse;
+
+  currentRepl: (args: ReplDataInclusion) => JsonDataReponse;
+  replById: (args: { id: string } & ReplDataInclusion) => JsonDataReponse;
+  replByUrl: (args: { url: string } & ReplDataInclusion) => JsonDataReponse;
 };
+
+export type JsonDataReponse = Promise<{ [key: string]: any } | never>;
+
+export interface UserDataInclusion {
+  includeSocialData?: boolean;
+  includeRoles?: boolean;
+}
+
+export interface ReplDataInclusion {
+  includeSocialData?: boolean;
+  includeComments?: boolean;
+  includeOwner?: boolean;
+  includeMultiplayers?: boolean;
+}
 
 export enum HandshakeStatus {
   Ready = "ready",


### PR DESCRIPTION
Add data API.  Note that this API wrapper is gated with a flag and won't work until we release to everyone.

## Example Usage

```js
import { data } from '@replit/extensions';

await data.user.current();

await data.repl.byId({
  id: "asdf-asdf-asdf-asdf-asdf"
})

await data.user.byUsername({
  username: "amasad",
  includeSocialData: true,
  includeRoles: true
});
```