### PR TITLE
Fix security vuln with Messages API module

### DIFF
--- a/src/api/messages.ts
+++ b/src/api/messages.ts
@@ -4,28 +4,28 @@ import { extensionPort } from "src";
  * Shows a confirmation toast message within the Replit workspace for `length` milliseconds.  Returns the ID of the message as a UUID
  */
 export const showConfirm = async (str: string, length: number = 4000) => {
-  return extensionPort.showConfirm(str, length);
+  return extensionPort.showConfirm(String(str), length);
 };
 
 /**
  * Shows an error toast message within the Replit workspace for `length` milliseconds.  Returns the ID of the message as a UUID
  */
 export const showError = async (str: string, length: number = 4000) => {
-  return extensionPort.showError(str, length);
+  return extensionPort.showError(String(str ), length);
 };
 
 /**
  * Shows a notice toast message within the Replit workspace for `length` milliseconds.  Returns the ID of the message as a UUID
  */
 export const showNotice = async (str: string, length: number = 4000) => {
-  return extensionPort.showNotice(str, length);
+  return extensionPort.showNotice(String(str), length);
 };
 
 /**
  * Shows a warning toast message within the Replit workspace for `length` milliseconds.  Returns the ID of the message as a UUID
  */
 export const showWarning = async (str: string, length: number = 4000) => {
-  return extensionPort.showWarning(str, length);
+  return extensionPort.showWarning(String(str), length);
 };
 
 /**


### PR DESCRIPTION
If you use the `messages` module and show a notice/message/warning/error with something other than a string (e.g. a JSON object), the whole workspace crashes.  I'm using the `String` function to make sure we're passing a string in.