### PR TITLE
[useReplitEffect] Switch to useEffect rather than useLayoutEffect

### DIFF
--- a/src/react/useReplitEffect.ts
+++ b/src/react/useReplitEffect.ts
@@ -1,10 +1,7 @@
-import { useLayoutEffect, useEffect } from "react";
+import { useEffect } from "react";
 import * as replit from "../index";
 import { HandshakeStatus } from "src/types";
 import useReplit from "./useReplit";
-
-const useIsomorphicLayoutEffect =
-  typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
 /**
  * Fires a callback with the Replit API wrapper when its dependency array changes.
@@ -16,7 +13,7 @@ export default function useReplitEffect(
 ) {
   const { replit, status } = useReplit();
 
-  return useIsomorphicLayoutEffect(() => {
+  return useEffect(() => {
     if (replit && status === HandshakeStatus.Ready) {
       callback(replit);
     }

--- a/src/react/useReplitEffect.ts
+++ b/src/react/useReplitEffect.ts
@@ -1,7 +1,10 @@
-import { useLayoutEffect } from "react";
+import { useLayoutEffect, useEffect } from "react";
 import * as replit from "../index";
 import { HandshakeStatus } from "src/types";
 import useReplit from "./useReplit";
+
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
 /**
  * Fires a callback with the Replit API wrapper when its dependency array changes.
@@ -13,7 +16,7 @@ export default function useReplitEffect(
 ) {
   const { replit, status } = useReplit();
 
-  return useLayoutEffect(() => {
+  return useIsomorphicLayoutEffect(() => {
     if (replit && status === HandshakeStatus.Ready) {
       callback(replit);
     }


### PR DESCRIPTION
The react warning about useLayoutEffect is really getting on my nerves.  Switching to plain `useEffect` supresses this in React when using an SSR framework like Next.js.