### PR TITLE
Fix file watching not working

### DIFF
--- a/src/api/fs/watching.ts
+++ b/src/api/fs/watching.ts
@@ -148,7 +148,7 @@ class TextFileWatcher {
     this.listeners.onReady();
   }
 
-  private handleChange({ changes: changeSpec }: { changes: ChangeSpec }) {    
+  private handleChange({ changes: changeJSON }: { changes: any }) {
     if (this.isDisposed) {
       return;
     }
@@ -157,7 +157,7 @@ class TextFileWatcher {
       throw new Error("unexpected handleOnChange called before handleOnReady");
     }
 
-    let changes = ChangeSet.fromJSON(changeSpec);
+    let changes = ChangeSet.fromJSON(changeJSON);
 
     this.state.remoteText = changes.apply(this.state.remoteText);
 

--- a/src/api/fs/watching.ts
+++ b/src/api/fs/watching.ts
@@ -148,7 +148,7 @@ class TextFileWatcher {
     this.listeners.onReady();
   }
 
-  private handleChange({ changes: changeSpec }: { changes: ChangeSpec }) {
+  private handleChange({ changes: changeSpec }: { changes: ChangeSpec }) {    
     if (this.isDisposed) {
       return;
     }
@@ -157,7 +157,8 @@ class TextFileWatcher {
       throw new Error("unexpected handleOnChange called before handleOnReady");
     }
 
-    let changes = ChangeSet.of(changeSpec, this.state.remoteText.length);
+    let changes = ChangeSet.fromJSON(changeSpec);
+
     this.state.remoteText = changes.apply(this.state.remoteText);
 
     for (const unconfirmed of this.state.unconfirmedChanges) {


### PR DESCRIPTION


We serialize the changset using `toJSON` in the workspace, I assumed we serialized it to a `ChangeSpec` compliant format.  I'm not sure how I didn't catch this issue earlier in my testing, but it works now.

# what changed

Use `ChangeSet.fromJSON` instead of `ChangeSet.of` to create the changeset

# Test

You can test it in my repl here https://replit.com/@replitfaris/extensions#dev/test.ts