### PR TITLE
Add support for nodejs module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
       "import": {
         "default": "./dist/index.js"
       },
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.cjs",
+      "require": "./dist/index.js"
     },
     "./react": {
       "types": "./dist/react/index.d.ts",
@@ -17,7 +18,8 @@
         "types": "./dist/react/index.d.ts",
         "default": "./dist/react/index.js"
       },
-      "default": "./dist/react/index.cjs"
+      "default": "./dist/react/index.cjs",
+      "require": "./dist/index.js"
     }
   },
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Creating a nodejs repl and importing stuff from `@replit/extensions` or `@replit/extensions/react` doesn't work since everything but nodejs module resolution works.