### PR TITLE
Improve init() function

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -5,7 +5,7 @@ import {
   useThemeValues,
   useReplitEffect,
 } from "@replit/extensions/react";
-import { UseWatchTextFileStatus, messages, init } from "@replit/extensions";
+import { UseWatchTextFileStatus, messages } from "@replit/extensions";
 import "./App.css";
 
 export default function App() {

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -5,7 +5,7 @@ import {
   useThemeValues,
   useReplitEffect,
 } from "@replit/extensions/react";
-import { UseWatchTextFileStatus, messages } from "@replit/extensions";
+import { UseWatchTextFileStatus, messages, init } from "@replit/extensions";
 import "./App.css";
 
 export default function App() {
@@ -88,6 +88,7 @@ export default function App() {
               <pre>{content}</pre>
             </div>
           )}
+          <span>{status}</span>
         </div>
       </div>
     </main>

--- a/src/apis.json
+++ b/src/apis.json
@@ -3,7 +3,11 @@
     "name": "init",
     "description": "The `init()` method initializes the Extension, establishes a handshake with the Repl, and adds an event listener to the window object. It takes as an argument an object containing optional parameters for the initialization process. It returns a function that removes the event listener added to the window object.",
     "isActive": true,
-    "typeNames": ["ReplitInitArgs", "OnHandshakeStatusListener"]
+    "typeNames": [
+      "ReplitInitArgs",
+      "OnHandshakeStatusListener",
+      "HandshakeStatus"
+    ]
   },
   {
     "name": "fs",

--- a/src/apis.json
+++ b/src/apis.json
@@ -3,11 +3,7 @@
     "name": "init",
     "description": "The `init()` method initializes the Extension, establishes a handshake with the Repl, and adds an event listener to the window object. It takes as an argument an object containing optional parameters for the initialization process. It returns a function that removes the event listener added to the window object.",
     "isActive": true,
-    "typeNames": [
-      "ReplitInitArgs",
-      "OnHandshakeStatusListener",
-      "HandshakeStatus"
-    ]
+    "typeNames": ["ReplitInitArgs", "ReplitInitOutput"]
   },
   {
     "name": "fs",

--- a/src/apis.json
+++ b/src/apis.json
@@ -2,7 +2,8 @@
   {
     "name": "init",
     "description": "The `init()` method initializes the Extension, establishes a handshake with the Repl, and adds an event listener to the window object. It takes as an argument an object containing optional parameters for the initialization process. It returns a function that removes the event listener added to the window object.",
-    "isActive": true
+    "isActive": true,
+    "typeNames": ["ReplitInitArgs", "OnHandshakeStatusListener"]
   },
   {
     "name": "fs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { setDebugMode } from "src/util/log";
+import { HandshakeStatus, ReplitInitArgs } from "./types";
 import { extensionPort, proxy } from "./util/comlink";
+import { getHandshakeStatus, setHandshakeStatus } from "./util/handshake"
 export * from "./api";
 export * from "./util/log";
 export { extensionPort, proxy };
@@ -14,11 +16,13 @@ function promiseWithTimeout<T>(promise: Promise<T>, timeout: number) {
   ]);
 }
 
-export async function init(args?: { timeout?: number; debug?: boolean }) {
+export async function init(args?: ReplitInitArgs) {
   if (extensionPort === null) {
     console.warn(`extensionPort is null. Was init() called in SSR?`);
-    return null;
+    return () => {};
   }
+
+  args?.onHandshakeStatus?.(getHandshakeStatus());
 
   setDebugMode(args?.debug || false);
 
@@ -33,10 +37,15 @@ export async function init(args?: { timeout?: number; debug?: boolean }) {
   try {
     await promiseWithTimeout(extensionPort.handshake(), args?.timeout || 2000);
 
+    setHandshakeStatus(HandshakeStatus.Ready);
+    args?.onHandshakeStatus?.(getHandshakeStatus());
+
     if (window) {
       window.document.addEventListener("click", onExtensionClick);
     }
   } catch (e) {
+    setHandshakeStatus(HandshakeStatus.Error);
+    args?.onHandshakeStatus?.(getHandshakeStatus());
     console.error(e);
     windDown();
     throw e;

--- a/src/react/useReplit.ts
+++ b/src/react/useReplit.ts
@@ -48,9 +48,10 @@ export function useReplit() {
 
     (async () => {
       try {
-        dispose = await replit.init();
+        dispose = await replit.init({
+          onHandshakeStatus: setStatus,
+        });
         setFilePath(await replit.me.filePath());
-        setStatus(HandshakeStatus.Ready);
       } catch (e) {
         setError(e as Error);
         setStatus(HandshakeStatus.Error);

--- a/src/react/useReplit.ts
+++ b/src/react/useReplit.ts
@@ -44,13 +44,11 @@ export function useReplit() {
       return;
     }
 
-    let dispose: (() => void) | null = () => {};
+    let dispose: () => void = () => {};
 
     (async () => {
       try {
-        dispose = await replit.init({
-          onHandshakeStatus: setStatus,
-        });
+        dispose = (await replit.init()).dispose;
         setFilePath(await replit.me.filePath());
       } catch (e) {
         setError(e as Error);
@@ -59,7 +57,7 @@ export function useReplit() {
     })();
 
     return () => {
-      dispose?.();
+      dispose();
     };
   }, []);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -397,12 +397,15 @@ export type WatchTextFileOnMoveOrDeleteListener = (
 export type HandshakeOuput = Promise<null | (() => void)>;
 export type OnThemeChangeValuesListener = (values: ThemeValuesGlobal) => void;
 export type OnThemeChangeListener = (theme: ThemeVersion) => void;
-export type OnHandshakeStatusListener = (status: HandshakeStatus) => void;
 
 export interface ReplitInitArgs {
   timeout?: number;
   debug?: boolean;
-  onHandshakeStatus?: OnHandshakeStatusListener;
+}
+
+export interface ReplitInitOutput {
+  dispose: () => void;
+  status: HandshakeStatus;
 }
 
 /*****************************************************************

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -397,6 +397,13 @@ export type WatchTextFileOnMoveOrDeleteListener = (
 export type HandshakeOuput = Promise<null | (() => void)>;
 export type OnThemeChangeValuesListener = (values: ThemeValuesGlobal) => void;
 export type OnThemeChangeListener = (theme: ThemeVersion) => void;
+export type OnHandshakeStatusListener = (status: HandshakeStatus) => void;
+
+export interface ReplitInitArgs {
+  timeout?: number;
+  debug?: boolean;
+  onHandshakeStatus?: OnHandshakeStatusListener;
+}
 
 /*****************************************************************
  * * Extension Port Wrapper


### PR DESCRIPTION
In a non-react Repl, it is very hard to see whether the handshake between Replit and the extension was established successfully.  Added an `onHandshakeStatus` callback in the init function and also removed an unused function.  Updated the useReplit hook to work with this as well.