### PR TITLE
Wait for window to load before attempting handshake

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ async function windowIsReady() {
       resolve();
       return;
     }
-    
+
     const loadHandler = () => {
       resolve();
       window.removeEventListener("load", loadHandler);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,22 @@ function promiseWithTimeout<T>(promise: Promise<T>, timeout: number) {
   ]);
 }
 
+async function windowIsReady() {
+  return new Promise<void>((resolve) => {
+    if (document.readyState === "complete") {
+      resolve();
+      return;
+    }
+    
+    const loadHandler = () => {
+      resolve();
+      window.removeEventListener("load", loadHandler);
+    };
+
+    window.addEventListener("load", loadHandler);
+  });
+}
+
 export async function init(args?: ReplitInitArgs): Promise<ReplitInitOutput> {
   if (extensionPort === null) {
     throw new Error("Extension must be initialized in a browser context");
@@ -32,6 +48,10 @@ export async function init(args?: ReplitInitArgs): Promise<ReplitInitOutput> {
   };
 
   try {
+    if (window) {
+      await windowIsReady();
+    }
+
     await promiseWithTimeout(extensionPort.handshake(), args?.timeout || 2000);
 
     setHandshakeStatus(HandshakeStatus.Ready);


### PR DESCRIPTION
Right now, when you call replit.init() before the document completes loading, it hangs forever. This happens because the replit workspace side extension port only starts listening for messages when loading completes. 

We currently solve for this in some of our templates by waiting for the document to complete loading, but we can wait for that ourselves and save extension authors the trouble.