### PR TITLE
Fix list indentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,20 @@
 
 The Replit Extensions client is a module that allows you to easily interact with the Workspace
 
- - Repositories
+- Repositories
   - https://github.com/replit/extensions
   - https://github.com/replit/extensions-react
- - NPM Packages
+- NPM Packages
   - https://www.npmjs.com/package/@replit/extensions
   - https://www.npmjs.com/package/@replit/extensions-react
- - [Documentation](https://docs.replit.com/extensions)
-  - [Resources](https://docs.replit.com/extensions/resources)
-  - [API Modules](https://docs.replit.com/extensions/category/api-reference)
-  - [React Client](https://docs.replit.com/extensions/category/react)
- - [Ask Forum](https://ask.replit.com/c/extensions)
- - [React Extension Template](https://replit.com/@replit/React-Extension?v=1)
- - [HTML/CSS/JS Extension Template](https://replit.com/@replit/HTMLCSSJS-Extension?v=1)
+- [GitHub Repository](https://github.com/replit/extensions)
+- [Documentation](https://docs.replit.com/extensions)
+   - [Resources](https://docs.replit.com/extensions/resources)
+   - [API Modules](https://docs.replit.com/extensions/category/api-reference)
+   - [React Client](https://docs.replit.com/extensions/category/react)
+- [Ask Forum](https://ask.replit.com/c/extensions)
+- [React Extension Template](https://replit.com/@replit/React-Extension?v=1)
+- [HTML/CSS/JS Extension Template](https://replit.com/@replit/HTMLCSSJS-Extension?v=1)
 
 [![Run on Replit button](https://user-images.githubusercontent.com/50180265/228865994-ccf7348e-ffb7-454e-bc4e-ce90df6c09bc.png)](https://replit.com/github/replit/extensions)
 


### PR DESCRIPTION
I think you tried to indent it but you only used one space instead of two. Now it also looks more similar to the README in the React Client repo.