### PR TITLE
Add User Editor Preferences to the Data Module

### DIFF
--- a/modules/example/App.tsx
+++ b/modules/example/App.tsx
@@ -12,14 +12,9 @@ export default function App() {
   }
 
   const execute = async () => {
-    const out = await experimental.exec({
-      args: "pnpm lint",
-      onOutput: (output) => {
-        messages.showConfirm(output);
-      },
-    });
+    const out = await experimental.editor.getPreferences();
 
-    messages.showWarning(out.output);
+    console.log(out);
   };
 
   return (

--- a/modules/extensions/src/api/data.ts
+++ b/modules/extensions/src/api/data.ts
@@ -1,10 +1,14 @@
-import { ReplDataInclusion, UserDataInclusion } from "../types";
+import {
+  ReplDataInclusion,
+  UserDataInclusion,
+  CurrentUserDataInclusion,
+} from "../types";
 import { extensionPort } from "../util/comlink";
 
 /**
  * Fetches the current user via graphql
  */
-export async function currentUser(args: UserDataInclusion) {
+export async function currentUser(args: CurrentUserDataInclusion) {
   return await extensionPort.currentUser(args);
 }
 

--- a/modules/extensions/src/api/experimental/editor.ts
+++ b/modules/extensions/src/api/experimental/editor.ts
@@ -1,5 +1,5 @@
-import { EditorPreferences } from "src/types";
-import { extensionPort } from "src/util/comlink";
+import { EditorPreferences } from "../../types";
+import { extensionPort } from "../../util/comlink";
 
 export async function getPreferences(): Promise<EditorPreferences> {
   return await extensionPort.experimental.editor.getPreferences();

--- a/modules/extensions/src/api/experimental/editor.ts
+++ b/modules/extensions/src/api/experimental/editor.ts
@@ -1,0 +1,6 @@
+import { EditorPreferences } from "src/types";
+import { extensionPort } from "src/util/comlink";
+
+export async function getPreferences(): Promise<EditorPreferences> {
+  return await extensionPort.experimental.editor.getPreferences();
+}

--- a/modules/extensions/src/api/experimental/index.ts
+++ b/modules/extensions/src/api/experimental/index.ts
@@ -1,1 +1,2 @@
 export { exec } from "./exec";
+export * from "./editor";

--- a/modules/extensions/src/api/experimental/index.ts
+++ b/modules/extensions/src/api/experimental/index.ts
@@ -1,2 +1,2 @@
 export { exec } from "./exec";
-export * from "./editor";
+export * as editor from "./editor";

--- a/modules/extensions/src/apis.json
+++ b/modules/extensions/src/apis.json
@@ -68,7 +68,11 @@
       "UserSocialType",
       "UserRole",
       "ReplOwner",
-      "ReplCommentConnection"
+      "ReplCommentConnection",
+      "CurrentUserDataInclusion",
+      "EditorPreferences",
+      "CurrentUser",
+      "CurrentUserQueryOutput"
     ]
   },
   {

--- a/modules/extensions/src/types/data.ts
+++ b/modules/extensions/src/types/data.ts
@@ -28,9 +28,7 @@ export interface User {
 /**
  * Extended values for the current user
  */
-export interface CurrentUser extends User {
-  editorPreferences: EditorPreferences;
-}
+export interface CurrentUser extends User {}
 
 /**
  * A user social media link
@@ -162,7 +160,6 @@ export interface CurrentUserDataInclusion {
   includeSocialData?: boolean;
   includeRoles?: boolean;
   includePlan?: boolean;
-  includeEditorPreferences?: boolean;
 }
 
 /**

--- a/modules/extensions/src/types/data.ts
+++ b/modules/extensions/src/types/data.ts
@@ -135,7 +135,6 @@ export interface ReplCommentConnection {
  * Editor Preferences
  */
 export interface EditorPreferences {
-  isLayoutStacked: boolean;
   fontSize: number;
   indentIsSpaces: boolean;
   indentSize: number;
@@ -143,13 +142,7 @@ export interface EditorPreferences {
   wrapping: boolean;
   codeIntelligence: boolean;
   codeSuggestion: boolean;
-  completeCodeEngine: string;
-  chatEngine: string;
-  accessibleTerminal: boolean;
   multiselectModifierKey: string;
-  webviewAutoOpenOnPortOpened: boolean;
-  extraDelight: boolean;
-  enableGpu: boolean;
   minimapDisplay: string;
 }
 

--- a/modules/extensions/src/types/data.ts
+++ b/modules/extensions/src/types/data.ts
@@ -26,6 +26,13 @@ export interface User {
 }
 
 /**
+ * Extended values for the current user
+ */
+export interface CurrentUser extends User {
+  editorPreferences: EditorPreferences;
+}
+
+/**
  * A user social media link
  */
 export interface UserSocial {
@@ -125,12 +132,44 @@ export interface ReplCommentConnection {
 }
 
 /**
+ * Editor Preferences
+ */
+export interface EditorPreferences {
+  isLayoutStacked: boolean;
+  fontSize: number;
+  indentIsSpaces: boolean;
+  indentSize: number;
+  keyboardHandler: string;
+  wrapping: boolean;
+  codeIntelligence: boolean;
+  codeSuggestion: boolean;
+  completeCodeEngine: string;
+  chatEngine: string;
+  accessibleTerminal: boolean;
+  multiselectModifierKey: string;
+  webviewAutoOpenOnPortOpened: boolean;
+  extraDelight: boolean;
+  enableGpu: boolean;
+  minimapDisplay: string;
+}
+
+/**
  * Options for user queries
  */
 export interface UserDataInclusion {
   includeSocialData?: boolean;
   includeRoles?: boolean;
   includePlan?: boolean;
+}
+
+/**
+ * Options for the currentUser query
+ */
+export interface CurrentUserDataInclusion {
+  includeSocialData?: boolean;
+  includeRoles?: boolean;
+  includePlan?: boolean;
+  includeEditorPreferences?: boolean;
 }
 
 /**
@@ -162,3 +201,8 @@ export type UserByUsernameQueryOutput = GraphResponse<{ userByUsername: User }>;
  * A graphql response for the user query
  */
 export type UserQueryOutput = GraphResponse<{ user: User }>;
+
+/**
+ * A graphql response for the currentUser query
+ */
+export type CurrentUserQueryOutput = GraphResponse<{ user: CurrentUser }>;

--- a/modules/extensions/src/types/index.ts
+++ b/modules/extensions/src/types/index.ts
@@ -12,6 +12,7 @@ import {
   ReplQueryOutput,
   CurrentUserQueryOutput,
   CurrentUserDataInclusion,
+  EditorPreferences,
 } from "./data";
 import {
   ThemeValuesGlobal,
@@ -193,6 +194,10 @@ export type ExperimentalAPI = {
       error: string | null;
     }>;
   }>;
+
+  editor: {
+    getPreferences: () => Promise<EditorPreferences>;
+  };
 };
 
 export type InternalAPI = {

--- a/modules/extensions/src/types/index.ts
+++ b/modules/extensions/src/types/index.ts
@@ -10,6 +10,8 @@ import {
   UserByUsernameQueryOutput,
   ReplDataInclusion,
   ReplQueryOutput,
+  CurrentUserQueryOutput,
+  CurrentUserDataInclusion,
 } from "./data";
 import {
   ThemeValuesGlobal,
@@ -157,7 +159,7 @@ export type ExtensionPortAPI = {
   hideAllMessages: () => void;
 
   // data Module
-  currentUser: (args: UserDataInclusion) => UserQueryOutput;
+  currentUser: (args: CurrentUserDataInclusion) => CurrentUserQueryOutput;
   userById: (args: { id: string } & UserDataInclusion) => UserQueryOutput;
   userByUsername: (
     args: { username: string } & UserDataInclusion


### PR DESCRIPTION
Some users have been requesting to user editor preferences through the data module.  This PR allows accessing it through the `currentUser` query.

Waiting on https://github.com/replit/repl-it-web/pull/32098 to reach prod first.