### PR TITLE
[React Client] Optional dependency array in useReplitEffect

### DIFF
--- a/modules/extensions-react/src/hooks/useReplitEffect.ts
+++ b/modules/extensions-react/src/hooks/useReplitEffect.ts
@@ -11,7 +11,7 @@ export default function useReplitEffect(
   callback: (
     r: typeof replit
   ) => void | Promise<void> | (() => void) | Promise<() => void>,
-  dependencies: Array<any>
+  dependencies?: Array<any>
 ) {
   const { replit, status } = useReplit();
 
@@ -25,5 +25,5 @@ export default function useReplitEffect(
         };
       }
     }
-  }, [...dependencies, replit, status]);
+  }, [...(dependencies || []), replit, status]);
 }

--- a/modules/extensions-react/src/hooks/useReplitEffect.ts
+++ b/modules/extensions-react/src/hooks/useReplitEffect.ts
@@ -15,15 +15,18 @@ export default function useReplitEffect(
 ) {
   const { replit, status } = useReplit();
 
-  return useEffect(() => {
-    if (replit && status === HandshakeStatus.Ready) {
-      const dispose = callback(replit);
+  return useEffect(
+    () => {
+      if (replit && status === HandshakeStatus.Ready) {
+        const dispose = callback(replit);
 
-      if (typeof dispose === "function") {
-        return () => {
-          dispose();
-        };
+        if (typeof dispose === "function") {
+          return () => {
+            dispose();
+          };
+        }
       }
-    }
-  }, [...(dependencies || []), replit, status]);
+    },
+    dependencies ? [...dependencies, replit, status] : undefined
+  );
 }


### PR DESCRIPTION
Typescript is not happy when you don't provide a dependency array in the useReplitEffect hook (second param).  Bad for devex.