### PR TITLE
Add Auth API

### DIFF
--- a/modules/example/package.json
+++ b/modules/example/package.json
@@ -17,6 +17,7 @@
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.2.4",
     "@vitejs/plugin-react": "^4.0.0",
+    "jose": "^4.14.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "vite": "^4.2.1"

--- a/modules/example/package.json
+++ b/modules/example/package.json
@@ -17,7 +17,6 @@
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.2.4",
     "@vitejs/plugin-react": "^4.0.0",
-    "jose": "^4.14.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "vite": "^4.2.1"

--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -6,10 +6,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-        "types": "./src/index.ts",
-        "import": {
-          "default": "./src/index.ts"
-        }
+      "types": "./src/index.ts",
+      "import": {
+        "default": "./src/index.ts"
+      }
     }
   },
   "publishConfig": {
@@ -48,7 +48,8 @@
   "license": "MIT",
   "dependencies": {
     "@codemirror/state": "^6.2.0",
-    "comlink": "^4.3.1"
+    "comlink": "^4.3.1",
+    "jose": "^4.14.4"
   },
   "devDependencies": {
     "esbuild": "^0.15.18",

--- a/modules/extensions/src/api/index.ts
+++ b/modules/extensions/src/api/index.ts
@@ -8,7 +8,17 @@ import * as session from "./session";
 import * as experimental from "./experimental";
 import * as internal from "./internal";
 
-export { fs, replDb, me, themes, messages, data, session, experimental, internal };
+export {
+  fs,
+  replDb,
+  me,
+  themes,
+  messages,
+  data,
+  session,
+  experimental,
+  internal,
+};
 
 // deprecate this after migrating existing extensions
 export * from "./fs";

--- a/modules/extensions/src/api/index.ts
+++ b/modules/extensions/src/api/index.ts
@@ -6,8 +6,9 @@ import * as messages from "./messages";
 import * as data from "./data";
 import * as session from "./session";
 import * as experimental from "./experimental";
+import * as internal from "./internal";
 
-export { fs, replDb, me, themes, messages, data, session, experimental };
+export { fs, replDb, me, themes, messages, data, session, experimental, internal };
 
 // deprecate this after migrating existing extensions
 export * from "./fs";

--- a/modules/extensions/src/api/internal/auth.ts
+++ b/modules/extensions/src/api/internal/auth.ts
@@ -1,0 +1,33 @@
+import { extensionPort } from "../../util/comlink";
+import jose from 'jose'
+
+export async function getAuthToken() {
+  // @ts-ignore
+  return extensionPort.internal.auth.getAuthToken();
+}
+
+export async function verifyAuthToken(token: string) {
+  const tokenHeaders = jose.decodeProtectedHeader(token);
+
+  if (tokenHeaders.typ !== 'JWT') {
+    throw new Error('Expected typ: JWT');
+  }
+
+  if (tokenHeaders.alg !== 'EdDSA') {
+    throw new Error('Expected alg: EdDSA');
+  }
+
+  if (!tokenHeaders.kid) {
+    throw new Error('Expected `kid` to be defined');
+  }
+
+  const res = await fetch(`https://replit.com/data/extensions/publicKey/${tokenHeaders.kid}`);
+
+  const publicKey = await res.text();
+
+  const importedPublicKey = await jose.importSPKI(publicKey, 'RS256')
+
+  const decodedToken = await jose.jwtVerify(token, importedPublicKey);
+
+  return decodedToken
+}

--- a/modules/extensions/src/api/internal/auth.ts
+++ b/modules/extensions/src/api/internal/auth.ts
@@ -1,5 +1,5 @@
 import { extensionPort } from "../../util/comlink";
-import jose from 'jose'
+import jose from "jose";
 
 export async function getAuthToken() {
   return extensionPort.internal.auth.getAuthToken();
@@ -8,25 +8,27 @@ export async function getAuthToken() {
 export async function verifyAuthToken(token: string) {
   const tokenHeaders = jose.decodeProtectedHeader(token);
 
-  if (tokenHeaders.typ !== 'JWT') {
-    throw new Error('Expected typ: JWT');
+  if (tokenHeaders.typ !== "JWT") {
+    throw new Error("Expected typ: JWT");
   }
 
-  if (tokenHeaders.alg !== 'EdDSA') {
-    throw new Error('Expected alg: EdDSA');
+  if (tokenHeaders.alg !== "EdDSA") {
+    throw new Error("Expected alg: EdDSA");
   }
 
   if (!tokenHeaders.kid) {
-    throw new Error('Expected `kid` to be defined');
+    throw new Error("Expected `kid` to be defined");
   }
 
-  const res = await fetch(`https://replit.com/data/extensions/publicKey/${tokenHeaders.kid}`);
+  const res = await fetch(
+    `https://replit.com/data/extensions/publicKey/${tokenHeaders.kid}`
+  );
 
   const publicKey = await res.text();
 
-  const importedPublicKey = await jose.importSPKI(publicKey, 'RS256')
+  const importedPublicKey = await jose.importSPKI(publicKey, "RS256");
 
   const decodedToken = await jose.jwtVerify(token, importedPublicKey);
 
-  return decodedToken
+  return decodedToken;
 }

--- a/modules/extensions/src/api/internal/auth.ts
+++ b/modules/extensions/src/api/internal/auth.ts
@@ -2,7 +2,6 @@ import { extensionPort } from "../../util/comlink";
 import jose from 'jose'
 
 export async function getAuthToken() {
-  // @ts-ignore
   return extensionPort.internal.auth.getAuthToken();
 }
 

--- a/modules/extensions/src/api/internal/index.ts
+++ b/modules/extensions/src/api/internal/index.ts
@@ -1,0 +1,1 @@
+export * as auth from "./auth";

--- a/modules/extensions/src/types/index.ts
+++ b/modules/extensions/src/types/index.ts
@@ -203,7 +203,9 @@ type Promisify<T> = T extends Promise<unknown> ? T : Promise<T>;
 
 type RemoteProperty<T> = T extends Function | Comlink.ProxyMarked
   ? Comlink.Remote<T>
-  : T extends object ? T : Promisify<T>; //  We don't want to promisify objects, but we do want to promisify all other primitives
+  : T extends object
+  ? T
+  : Promisify<T>; //  We don't want to promisify objects, but we do want to promisify all other primitives
 
 type RemoteObject<T> = {
   [P in keyof T]: RemoteProperty<T[P]>;

--- a/modules/extensions/src/types/index.ts
+++ b/modules/extensions/src/types/index.ts
@@ -174,7 +174,7 @@ export type ExtensionPortAPI = {
   internal: InternalAPI;
 };
 
-export interface ExperimentalAPI {
+export type ExperimentalAPI = {
   exec: (args: {
     splitStderr?: boolean;
     args: Array<string>;
@@ -193,13 +193,16 @@ export interface ExperimentalAPI {
   }>;
 }
 
-export interface InternalAPI {
+export type InternalAPI = {
   auth: {
     getAuthToken: () => Promise<string>
   }
 }
 
-export type ExtensionPort = Comlink.Remote<ExtensionPortAPI> & {
-  experimental: Comlink.RemoteObject<ExperimentalAPI>;
-  internal: Comlink.RemoteObject<InternalAPI>;
+type RemoteProperty<T> = T extends Function | Comlink.ProxyMarked ? Comlink.Remote<T> : T;
+
+type RemoteObject<T> = {
+  [P in keyof T]: RemoteProperty<T[P]>;
 };
+
+export type ExtensionPort = RemoteObject<ExtensionPortAPI>

--- a/modules/extensions/src/types/index.ts
+++ b/modules/extensions/src/types/index.ts
@@ -169,6 +169,9 @@ export type ExtensionPortAPI = {
   // session Module
   watchActiveFile: (callback: OnActiveFileChangeListener) => DisposerFunction;
   getActiveFile: () => Promise<string | null>;
+
+  experimental: ExperimentalAPIs;
+  internal: InternalAPIs;
 };
 
 export interface ExperimentalAPI {
@@ -193,3 +196,8 @@ export interface ExperimentalAPI {
 export type ExtensionPort = Comlink.Remote<ExtensionPortAPI> & {
   experimental: Comlink.RemoteObject<ExperimentalAPI>;
 };
+export interface InternalAPIs {
+  auth: {
+    getAuthToken: () => Promise<string>
+  }
+}

--- a/modules/extensions/src/types/index.ts
+++ b/modules/extensions/src/types/index.ts
@@ -199,9 +199,11 @@ export type InternalAPI = {
   };
 };
 
+type Promisify<T> = T extends Promise<unknown> ? T : Promise<T>;
+
 type RemoteProperty<T> = T extends Function | Comlink.ProxyMarked
   ? Comlink.Remote<T>
-  : T;
+  : T extends object ? T : Promisify<T>; //  We don't want to promisify objects, but we do want to promisify all other primitives
 
 type RemoteObject<T> = {
   [P in keyof T]: RemoteProperty<T[P]>;

--- a/modules/extensions/src/types/index.ts
+++ b/modules/extensions/src/types/index.ts
@@ -191,18 +191,20 @@ export type ExperimentalAPI = {
       error: string | null;
     }>;
   }>;
-}
+};
 
 export type InternalAPI = {
   auth: {
-    getAuthToken: () => Promise<string>
-  }
-}
+    getAuthToken: () => Promise<string>;
+  };
+};
 
-type RemoteProperty<T> = T extends Function | Comlink.ProxyMarked ? Comlink.Remote<T> : T;
+type RemoteProperty<T> = T extends Function | Comlink.ProxyMarked
+  ? Comlink.Remote<T>
+  : T;
 
 type RemoteObject<T> = {
   [P in keyof T]: RemoteProperty<T[P]>;
 };
 
-export type ExtensionPort = RemoteObject<ExtensionPortAPI>
+export type ExtensionPort = RemoteObject<ExtensionPortAPI>;

--- a/modules/extensions/src/types/index.ts
+++ b/modules/extensions/src/types/index.ts
@@ -201,3 +201,6 @@ export interface InternalAPIs {
     getAuthToken: () => Promise<string>
   }
 }
+export type ExtensionPort = Comlink.Remote<ExtensionPortAPI> & {
+  experimental: Comlink.RemoteObject<ExperimentalAPI>;
+};

--- a/modules/extensions/src/types/index.ts
+++ b/modules/extensions/src/types/index.ts
@@ -170,8 +170,8 @@ export type ExtensionPortAPI = {
   watchActiveFile: (callback: OnActiveFileChangeListener) => DisposerFunction;
   getActiveFile: () => Promise<string | null>;
 
-  experimental: ExperimentalAPIs;
-  internal: InternalAPIs;
+  experimental: ExperimentalAPI;
+  internal: InternalAPI;
 };
 
 export interface ExperimentalAPI {
@@ -193,14 +193,13 @@ export interface ExperimentalAPI {
   }>;
 }
 
-export type ExtensionPort = Comlink.Remote<ExtensionPortAPI> & {
-  experimental: Comlink.RemoteObject<ExperimentalAPI>;
-};
-export interface InternalAPIs {
+export interface InternalAPI {
   auth: {
     getAuthToken: () => Promise<string>
   }
 }
+
 export type ExtensionPort = Comlink.Remote<ExtensionPortAPI> & {
   experimental: Comlink.RemoteObject<ExperimentalAPI>;
+  internal: Comlink.RemoteObject<InternalAPI>;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,7 @@ importers:
       '@types/react': ^18.0.28
       '@types/react-dom': ^18.2.4
       '@vitejs/plugin-react': ^4.0.0
+      jose: ^4.14.4
       prettier: ^2.7.1
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -49,6 +50,7 @@ importers:
       '@types/react': 18.2.6
       '@types/react-dom': 18.2.4
       '@vitejs/plugin-react': 4.0.0_vite@4.3.5
+      jose: 4.14.4
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       vite: 4.3.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,7 @@ importers:
       '@codemirror/state': ^6.2.0
       comlink: ^4.3.1
       esbuild: ^0.15.18
+      jose: ^4.14.4
       prettier: ^2.7.1
       tsup: ^6.6.3
       typedoc: ^0.23.21
@@ -67,6 +68,7 @@ importers:
     dependencies:
       '@codemirror/state': 6.2.0
       comlink: 4.4.1
+      jose: 4.14.4
     devDependencies:
       esbuild: 0.15.18
       prettier: 2.8.8
@@ -1978,6 +1980,10 @@ packages:
   /isexe/2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
+
+  /jose/4.14.4:
+    resolution: {integrity: sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==}
+    dev: false
 
   /joycon/3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}


### PR DESCRIPTION
This adds an Auth API to the extensions client, making it possible for an extension frontend or backend to reliably know if an extension has been loaded by replit