### PR TITLE
Exported version from package

### DIFF
--- a/modules/extensions/src/index.ts
+++ b/modules/extensions/src/index.ts
@@ -7,6 +7,8 @@ export * from "./util/log";
 export { extensionPort, proxy };
 export * from "./types";
 
+export { version } from '../package.json';
+
 function promiseWithTimeout<T>(promise: Promise<T>, timeout: number) {
   return Promise.race([
     promise,

--- a/modules/extensions/src/index.ts
+++ b/modules/extensions/src/index.ts
@@ -7,7 +7,7 @@ export * from "./util/log";
 export { extensionPort, proxy };
 export * from "./types";
 
-export { version } from '../package.json';
+export { version } from "../package.json";
 
 function promiseWithTimeout<T>(promise: Promise<T>, timeout: number) {
   return Promise.race([


### PR DESCRIPTION
Useful for debugging reasons

This lets you access the version of this package by running `replit.version` or `import { version } from '@replit/extensions'`