### PR TITLE
Fix platform

### DIFF
--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/extensions",
-  "version": "1.1.2-beta.0",
+  "version": "1.4.0",
   "description": "The Replit Extensions client is a module that allows you to easily interact with the Workspace.",
   "types": "./src/index.ts",
   "exports": {
@@ -29,7 +29,7 @@
   "type": "module",
   "unpkg": "dist/index.global.js",
   "scripts": {
-    "build": "tsup src/index.ts  --sourcemap --dts --format esm,cjs,iife --global-name replit",
+    "build": "tsup src/index.ts  --sourcemap --dts --platform browser --format esm,cjs,iife --global-name replit",
     "lint": "npx prettier --write src/*",
     "lint:check": "npx prettier -l src/*",
     "type:check": "tsc --noEmit",


### PR DESCRIPTION
We imported `jose` in #60 which worked fine in our example (which loaded ES modules) but broke our unpkg imports since we were accidentally bundling for node and not the browser

I tested this by:

- `pnpm build`
- copy `modules/extensions/dist/index.global.js`
- paste into browser
- no error!

You can reproduce the current error by following those steps off the main branch before this is PR merged

The `--platform` option I made use of is actually undocumented in tsup docs