### PR TITLE
Add optional parameters for devex

### DIFF
--- a/modules/extensions/src/api/data.ts
+++ b/modules/extensions/src/api/data.ts
@@ -8,8 +8,8 @@ import { extensionPort } from "../util/comlink";
 /**
  * Fetches the current user via graphql
  */
-export async function currentUser(args: CurrentUserDataInclusion) {
-  return await extensionPort.currentUser(args);
+export async function currentUser(args?: CurrentUserDataInclusion) {
+  return await extensionPort.currentUser(args || {});
 }
 
 /**
@@ -43,8 +43,8 @@ export async function userByUsername(
 /**
  * Fetches the current Repl via graphql
  */
-export async function currentRepl(args: ReplDataInclusion) {
-  return await extensionPort.currentRepl(args);
+export async function currentRepl(args?: ReplDataInclusion) {
+  return await extensionPort.currentRepl(args || {});
 }
 
 /**

--- a/modules/extensions/src/api/data.ts
+++ b/modules/extensions/src/api/data.ts
@@ -8,8 +8,8 @@ import { extensionPort } from "../util/comlink";
 /**
  * Fetches the current user via graphql
  */
-export async function currentUser(args?: CurrentUserDataInclusion) {
-  return await extensionPort.currentUser(args || {});
+export async function currentUser(args: CurrentUserDataInclusion = {}) {
+  return await extensionPort.currentUser(args);
 }
 
 /**

--- a/modules/extensions/src/api/data.ts
+++ b/modules/extensions/src/api/data.ts
@@ -43,7 +43,7 @@ export async function userByUsername(
 /**
  * Fetches the current Repl via graphql
  */
-export async function currentRepl(args?: ReplDataInclusion) {
+export async function currentRepl(args: ReplDataInclusion = {}) {
   return await extensionPort.currentRepl(args || {});
 }
 

--- a/modules/extensions/src/api/data.ts
+++ b/modules/extensions/src/api/data.ts
@@ -44,7 +44,7 @@ export async function userByUsername(
  * Fetches the current Repl via graphql
  */
 export async function currentRepl(args: ReplDataInclusion = {}) {
-  return await extensionPort.currentRepl(args || {});
+  return await extensionPort.currentRepl(args);
 }
 
 /**

--- a/modules/extensions/src/api/replDb.ts
+++ b/modules/extensions/src/api/replDb.ts
@@ -17,8 +17,8 @@ export async function get(args: { key: string }) {
 /**
  * Lists keys in the replDb. Accepts an optional `prefix`, which filters for keys beginning with the given prefix. Required [permissions](/extensions/api/manifest#scopetype): `repldb:read`.
  */
-export async function list(args: { prefix: string }) {
-  return extensionPort.listReplDbKeys(args.prefix);
+export async function list(args?: { prefix?: string }) {
+  return extensionPort.listReplDbKeys(args?.prefix || "");
 }
 
 /**

--- a/modules/extensions/src/api/replDb.ts
+++ b/modules/extensions/src/api/replDb.ts
@@ -17,7 +17,7 @@ export async function get(args: { key: string }) {
 /**
  * Lists keys in the replDb. Accepts an optional `prefix`, which filters for keys beginning with the given prefix. Required [permissions](/extensions/api/manifest#scopetype): `repldb:read`.
  */
-export async function list(args?: { prefix?: string }) {
+export async function list(args: { prefix?: string } = {}) {
   return extensionPort.listReplDbKeys(args?.prefix || "");
 }
 


### PR DESCRIPTION
It's annoying to have to do `data.currentUser({})` with an empty object since no additional fields are getting fetched.  Added the option to not provide the argument at all to a few methods.