### PR TITLE
Unexperimentalize exec() (WIP)

### DIFF
--- a/modules/extensions/src/api/exec.ts
+++ b/modules/extensions/src/api/exec.ts
@@ -1,0 +1,69 @@
+import { extensionPort, proxy } from "../util/comlink";
+import {
+  CombinedOutputExecOptions,
+  CombinedOutputExecResult,
+  SeparatedOutputExecOptions,
+  SeparatedOutputExecResult,
+} from "../types";
+
+/**
+ * Executes arbitrary shell commands, with given arguments and environment variables
+ */
+export async function exec(
+  combinedOutputOptions: CombinedOutputExecOptions
+): Promise<CombinedOutputExecResult>;
+export async function exec(
+  separatedOutputOptions: SeparatedOutputExecOptions
+): Promise<SeparatedOutputExecResult>;
+export async function exec(
+  options: CombinedOutputExecOptions | SeparatedOutputExecOptions
+): Promise<SeparatedOutputExecResult | CombinedOutputExecResult> {
+  let outputStr: string = "";
+  let errorStr: string = "";
+  let exitCode: string = "";
+
+  const { promise } = await extensionPort.experimental.exec(
+    proxy({
+      args: Array.isArray(options.args)
+        ? options.args
+        : ["bash", "-c", options.args],
+      env: options.env || {},
+      splitStderr: options.separateStdErr || false,
+      onOutput: (output: string) => {
+        outputStr += output;
+        if (options.separateStdErr) {
+          options.onStdOutOutput?.(output);
+        } else {
+          options.onOutput?.(output);
+        }
+      },
+      onStdErr: (stderr: string) => {
+        if (options.separateStdErr) {
+          errorStr += stderr;
+          options.onStdErrOutput?.(stderr);
+        } else {
+          outputStr += stderr;
+          options.onOutput?.(stderr);
+        }
+      },
+      onError: (err: Error) => {
+        throw err;
+      },
+    })
+  );
+
+  await promise;
+
+  if (options.separateStdErr) {
+    return {
+      output: outputStr,
+      error: errorStr,
+      exitError: exitCode || null,
+    };
+  } else {
+    return {
+      output: outputStr,
+      exitError: exitCode || null,
+    };
+  }
+}

--- a/modules/extensions/src/api/index.ts
+++ b/modules/extensions/src/api/index.ts
@@ -7,6 +7,7 @@ import * as data from "./data";
 import * as session from "./session";
 import * as experimental from "./experimental";
 import * as internal from "./internal";
+import * as exec from "./exec";
 
 export {
   fs,
@@ -18,6 +19,7 @@ export {
   session,
   experimental,
   internal,
+  exec,
 };
 
 // deprecate this after migrating existing extensions

--- a/modules/extensions/src/apis.json
+++ b/modules/extensions/src/apis.json
@@ -111,8 +111,7 @@
       "CombinedOutputExecOptions",
       "SeparatedOutputExecOptions",
       "OutputStrCallback"
-    ],
-    "experimental": true
+    ]
   },
   {
     "name": "editor",


### PR DESCRIPTION
Make exec() API not experimental anymore.  Waiting on the correct kill method.