### PR TITLE
[exec] executeCommand & exec APIs

### DIFF
--- a/modules/extensions/src/api/experimental/exec.ts
+++ b/modules/extensions/src/api/experimental/exec.ts
@@ -3,7 +3,7 @@ import {
   SpawnOptions,
   SpawnOutput,
   SpawnResult,
-} from "src/types/exec";
+} from "../../types/exec";
 import { extensionPort, proxy } from "../../util/comlink";
 
 /**

--- a/modules/extensions/src/api/experimental/exec.ts
+++ b/modules/extensions/src/api/experimental/exec.ts
@@ -99,4 +99,4 @@ async function exec(
 
 exec.executeCommand = executeCommand;
 
-export default exec;
+export { exec };

--- a/modules/extensions/src/api/experimental/exec.ts
+++ b/modules/extensions/src/api/experimental/exec.ts
@@ -65,17 +65,13 @@ async function exec(
     env?: Record<string, string>;
   } = {}
 ): Promise<ExecResult> {
-  let stderr = "";
-  let stdout = "";
+  let output = "";
   const { resultPromise } = spawn({
     args: ["bash", "-c", command],
     env: options.env ?? {},
-    splitStderr: true,
-    onStdErr: (output: string) => {
-      stderr += output;
-    },
-    onStdOut: (output: string) => {
-      stdout += output;
+    splitStderr: false,
+    onOutput: (newOutput: string) => {
+      output += newOutput;
     },
   });
 
@@ -86,8 +82,7 @@ async function exec(
   }
 
   return {
-    stdout,
-    stderr,
+    output,
     exitCode: result.exitCode,
   };
 }

--- a/modules/extensions/src/api/experimental/index.ts
+++ b/modules/extensions/src/api/experimental/index.ts
@@ -1,2 +1,2 @@
-export { exec } from "./exec";
+export * as exec from "./exec";
 export * as editor from "./editor";

--- a/modules/extensions/src/types/exec.ts
+++ b/modules/extensions/src/types/exec.ts
@@ -47,5 +47,5 @@ export interface ExecOutput<
   T = CombinedOutputExecResult | SeparatedOutputExecResult
 > {
   dispose: () => void;
-  result: Promise<T>;
+  resultPromise: Promise<T>;
 }

--- a/modules/extensions/src/types/exec.ts
+++ b/modules/extensions/src/types/exec.ts
@@ -1,51 +1,42 @@
-export interface CombinedOutputExecResult {
-  /** Buffered standard out and standard error outputs combined */
-  output: string;
-  /** This is usually a string containing an exit code if non-zero exit */
-  exitCode: number | null;
-  /** Execution Channel Error */
-  error: string | null;
-}
-
-export interface SeparatedOutputExecResult {
-  /** Buffered standard out output */
-  stdOut: string;
-  /** Buffered standard error output */
-  stdErr: string;
-  /** Execution Channel Error */
-  error: string | null;
-  /** This is usually a string containing an exit code if non-zero exit */
-  exitCode: number | null;
-}
-
-export interface BaseExecOptions {
-  /** whether to keep standard out and standard error outputs separate */
-  separateStdErr?: boolean;
-  /** arguments for the command, can be an array of arguments, or a string interpreted by bash */
-  args: string | Array<string>;
-  /** any environment variables to add to the execution context */
-  env?: Record<string, string>;
-}
-
-export interface CombinedOutputExecOptions extends BaseExecOptions {
-  separateStdErr?: false;
-  /** output of the command will have standard out and standard error combined */
-  onOutput?: OutputStrCallback;
-}
-
-export interface SeparatedOutputExecOptions extends BaseExecOptions {
-  separateStdErr: true;
-  /** output of the command on standard out */
-  onStdOut?: OutputStrCallback;
-  /** output of the command on standard error */
-  onStdErr?: OutputStrCallback;
-}
-
 export type OutputStrCallback = (output: string) => void;
 
-export interface ExecOutput<
-  T = CombinedOutputExecResult | SeparatedOutputExecResult
-> {
+export type BaseSpawnOptions = {
+  /** The command and arguments, as an array. This does not spawn with a shell */
+  args: string[];
+  /** any environment variables to add to the execution context */
+  env?: Record<string, string>;
+  /** whether to keep stdout and standard error outputs separate */
+  splitStderr?: boolean;
+};
+
+type SplitStderrSpawnOptions = BaseSpawnOptions & {
+  splitStderr: true;
+  /* callback that's triggered when stdout is written to */
+  onStdOut?: OutputStrCallback;
+  /* callback that's triggered when stderr is written to */
+  onStdErr?: OutputStrCallback;
+};
+
+type CombinedStderrSpawnOptions = BaseSpawnOptions & {
+  splitStderr?: false;
+  /* callback that's triggered when stdout or stderr are written to */
+  onOutput?: (output: string) => void;
+};
+
+export type SpawnOptions = SplitStderrSpawnOptions | CombinedStderrSpawnOptions;
+
+export type SpawnResult = {
+  exitCode: number;
+  error: string | null;
+};
+
+export type SpawnOutput = {
   dispose: () => void;
-  resultPromise: Promise<T>;
-}
+  resultPromise: Promise<SpawnResult>;
+};
+
+export type ExecResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};

--- a/modules/extensions/src/types/exec.ts
+++ b/modules/extensions/src/types/exec.ts
@@ -36,7 +36,6 @@ export type SpawnOutput = {
 };
 
 export type ExecResult = {
-  stdout: string;
-  stderr: string;
+  output: string;
   exitCode: number;
 };


### PR DESCRIPTION
## The current state

the exec API has a somewhat verbose syntax. To just run a command, you need to do:

```javascript
const { promise, dispose } = await replit.exec({ args: "npm i" });
const {output, error, exitCode} = await promise;
if (error) {
  throw error;
}
if (exitCode !== 0) {
  throw new Error("Non zero exit code")
}
```

While we intended to have a simpler API, some complexity crept in because we wanted to support some use cases like long running processes (with the ability to kill them), and have the ability to consume stdout and stderr separately.

But I just don't wanna write all that code to run a simple command in the container. Most people will probably end up wrapping that method for simplicity. We should just do it ourselves.

## The new state

Now I can just call 

```javascript
const { stdout, stderr } = await replit.exec("npm i");
```

This throws if anything goes wrong (container, crosis, or command), and leaves you with the buffered result as output

The old API is now called executeCommand. We will suggest that people only use this for long running commands or if they need more control.

For usage semantics, I assigned executeCommand to exec, so the top level API looks like

```
replit.exec()
replit.exec.executeCommand()
```