### PR TITLE
Separate Action-Required Tests from Required tests

### DIFF
--- a/modules/dev/src/components/Header.tsx
+++ b/modules/dev/src/components/Header.tsx
@@ -49,7 +49,7 @@ export default function Header() {
         </button>
         <button
           className="button"
-          id="runTestsRequired"
+          id="runAllTests"
           style={{ marginRight: 8 }}
           onClick={() => {
             setTestQueue(

--- a/modules/dev/src/components/Header.tsx
+++ b/modules/dev/src/components/Header.tsx
@@ -27,19 +27,42 @@ export default function Header() {
         </span>
       </div>
 
-      <button
-        className="button"
-        onClick={() => {
-          setTestQueue(
-            tests.map((test) => ({ key: test.key, module: test.module }))
-          );
-          setFailedTests(0);
-          setPassedTests(0);
-          setTotalTests(tests.length);
-        }}
-      >
-        Run All Tests
-      </button>
+      <div style={{ display: "flex" }}>
+        <button
+          className="button"
+          id="runTestsRequired"
+          style={{ marginRight: 8 }}
+          onClick={() => {
+            setTestQueue(
+              tests
+                .filter((t) => t.module !== "actionRequired")
+                .map((test) => ({ key: test.key, module: test.module }))
+            );
+            setFailedTests(0);
+            setPassedTests(0);
+            setTotalTests(
+              tests.filter((t) => t.module !== "actionRequired").length
+            );
+          }}
+        >
+          Run Required
+        </button>
+        <button
+          className="button"
+          id="runTestsRequired"
+          style={{ marginRight: 8 }}
+          onClick={() => {
+            setTestQueue(
+              tests.map((test) => ({ key: test.key, module: test.module }))
+            );
+            setFailedTests(0);
+            setPassedTests(0);
+            setTotalTests(tests.length);
+          }}
+        >
+          Run All
+        </button>
+      </div>
     </div>
   );
 }

--- a/modules/dev/src/components/Test.tsx
+++ b/modules/dev/src/components/Test.tsx
@@ -16,7 +16,6 @@ export const UnitTest = ({
     testQueue,
     setTestQueue,
     setLogs,
-    passedTests,
     setPassedTests,
     setFailedTests,
   } = useAppState();

--- a/modules/dev/src/tests/actionRequired.ts
+++ b/modules/dev/src/tests/actionRequired.ts
@@ -1,0 +1,56 @@
+import { TestNamespace, TestObject } from "../types";
+import { themes, session } from "@replit/extensions";
+import { assert } from "chai";
+
+const tests: TestObject = {
+  "onActiveFileChange should watch the current active file": async (log) => {
+    log("⚠️ Please focus three different files for this test to finish ⚠️");
+
+    let fileVisits = 0;
+
+    await new Promise<void>((resolve) => {
+      const dispose = session.onActiveFileChange((file) => {
+        if (typeof file === "string") {
+          log(file + ` (${fileVisits}/3)`);
+          fileVisits++;
+          if (fileVisits >= 3) {
+            dispose();
+            resolve();
+          }
+        }
+      });
+    });
+  },
+  "onThemeChange fires when the theme changes": async (log) => {
+    log("⚠️ Please change your theme to run this test ⚠️");
+
+    await new Promise<void>(async (resolve) => {
+      const dispose = await themes.onThemeChange(() => {
+        dispose();
+        resolve();
+      });
+    });
+  },
+  "onThemeChangeValues fires when the theme changes": async (log) => {
+    log("⚠️ Please change your theme to run this test ⚠️");
+
+    await new Promise<void>(async (resolve) => {
+      const dispose = await themes.onThemeChangeValues((values) => {
+        assert.isObject(values);
+        assert.isTrue(
+          Object.values(values).every((t) => typeof t === "string")
+        );
+
+        dispose();
+        resolve();
+      });
+    });
+  },
+};
+
+const ActionRequiredTests: TestNamespace = {
+  module: "actionRequired",
+  tests,
+};
+
+export default ActionRequiredTests;

--- a/modules/dev/src/tests/index.ts
+++ b/modules/dev/src/tests/index.ts
@@ -7,6 +7,7 @@ import replDb from "./replDb";
 import themes from "./themes";
 import editor from "./editor";
 import exec from "./exec";
+import actionRequired from "./actionRequired";
 import { Module, TestNamespace } from "../types";
 
 const UnitTests: Record<Module, TestNamespace> = {
@@ -19,6 +20,7 @@ const UnitTests: Record<Module, TestNamespace> = {
   editor,
   exec,
   data,
+  actionRequired,
 };
 
 export default UnitTests;

--- a/modules/dev/src/tests/session.ts
+++ b/modules/dev/src/tests/session.ts
@@ -8,24 +8,6 @@ const tests: TestObject = {
 
     assert.isTrue(typeof res === "string" || res === null);
   },
-  "onActiveFileChange should watch the current active file": async (log) => {
-    log("⚠️ Please focus three different files for this test to finish ⚠️");
-
-    let fileVisits = 0;
-
-    await new Promise<void>((resolve) => {
-      const dispose = session.onActiveFileChange((file) => {
-        if (typeof file === "string") {
-          log(file + ` (${fileVisits}/3)`);
-          fileVisits++;
-          if (fileVisits >= 3) {
-            dispose();
-            resolve();
-          }
-        }
-      });
-    });
-  },
 };
 
 const SessionTests: TestNamespace = {

--- a/modules/dev/src/tests/themes.ts
+++ b/modules/dev/src/tests/themes.ts
@@ -25,31 +25,6 @@ const tests: TestObject = {
     assert.isObject(res);
     assert.isTrue(Object.values(res).every((t) => typeof t === "string"));
   },
-  "onThemeChange fires when the theme changes": async (log) => {
-    log("⚠️ Please change your theme to run this test ⚠️");
-
-    await new Promise<void>(async (resolve) => {
-      const dispose = await themes.onThemeChange(() => {
-        dispose();
-        resolve();
-      });
-    });
-  },
-  "onThemeChangeValues fires when the theme changes": async (log) => {
-    log("⚠️ Please change your theme to run this test ⚠️");
-
-    await new Promise<void>(async (resolve) => {
-      const dispose = await themes.onThemeChangeValues((values) => {
-        assert.isObject(values);
-        assert.isTrue(
-          Object.values(values).every((t) => typeof t === "string")
-        );
-
-        dispose();
-        resolve();
-      });
-    });
-  },
 };
 
 const ThemeTests: TestNamespace = {

--- a/modules/dev/src/types.ts
+++ b/modules/dev/src/types.ts
@@ -10,7 +10,8 @@ export type Module =
   | "messages"
   | "replDb"
   | "session"
-  | "themes";
+  | "themes"
+  | "actionRequired";
 
 export interface Test {
   module: Module;


### PR DESCRIPTION
Added two buttons, one of which runs required tests and the other that runs all tests.  Action-required tests require you to perform an action (e.g. switching a theme or going to different files).

![Screen Shot 2023-06-02 at 3 42 42 PM](https://github.com/replit/extensions/assets/50180265/897201f6-e3e5-43a9-a3da-705c2ba201f6)
