### PR TITLE
Fixed theme test

### DIFF
--- a/modules/dev/src/tests/themes.ts
+++ b/modules/dev/src/tests/themes.ts
@@ -7,13 +7,19 @@ const tests: TestObject = {
     const res = await themes.getCurrentTheme();
 
     assert.isObject(res);
-    assert.isNumber(res.id);
     assert.isTrue(
-      res.customTheme?.colorScheme === "dark" ||
-        res.customTheme?.colorScheme === "light"
+      typeof res.id === "number" ||
+        ["replitDark", "replitLight"].includes(res.id)
     );
-    assert.isString(res.customTheme?.title);
-    assert.isString(res.customTheme?.author.username);
+
+    if (res.customTheme) {
+      assert.isTrue(
+        res.customTheme?.colorScheme === "dark" ||
+          res.customTheme?.colorScheme === "light"
+      );
+      assert.isString(res.customTheme?.title);
+      assert.isString(res.customTheme?.author.username);
+    }
 
     log(
       `Theme: ${res.customTheme?.title} by ${res.customTheme?.author.username} (${res.customTheme?.colorScheme})`


### PR DESCRIPTION
The tests don't work if you are on the two inbuilt themes, because their ids are strings and not numbers. I adapted the tests to work for both inbuilt and custom themes.

