### PR TITLE
Auth API changes

### DIFF
--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -49,6 +49,7 @@
   "license": "MIT",
   "dependencies": {
     "@codemirror/state": "^6.2.0",
+    "@yoursunny/webcrypto-ed25519": "^0.0.20221020",
     "comlink": "^4.3.1",
     "jose": "^4.14.4"
   },

--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/extensions",
-  "version": "1.5.0-beta.2",
+  "version": "1.5.0-beta.3",
   "description": "The Replit Extensions client is a module that allows you to easily interact with the Workspace.",
   "types": "./src/index.ts",
   "exports": {

--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/extensions",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0-beta.2",
   "description": "The Replit Extensions client is a module that allows you to easily interact with the Workspace.",
   "types": "./src/index.ts",
   "exports": {

--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -51,7 +51,6 @@
     "@codemirror/state": "^6.2.0",
     "@noble/curves": "^1.0.0",
     "@root/asn1": "^1.0.0",
-    "@yoursunny/webcrypto-ed25519": "^0.0.20221020",
     "b64u-lite": "^1.1.0",
     "comlink": "^4.3.1",
     "jose": "^4.14.4"

--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -49,11 +49,15 @@
   "license": "MIT",
   "dependencies": {
     "@codemirror/state": "^6.2.0",
+    "@noble/curves": "^1.0.0",
+    "@root/asn1": "^1.0.0",
     "@yoursunny/webcrypto-ed25519": "^0.0.20221020",
+    "b64u-lite": "^1.1.0",
     "comlink": "^4.3.1",
     "jose": "^4.14.4"
   },
   "devDependencies": {
+    "@types/root__asn1": "^1.0.2",
     "esbuild": "^0.15.18",
     "prettier": "^2.7.1",
     "tsup": "^6.6.3",

--- a/modules/extensions/src/api/experimental/auth.ts
+++ b/modules/extensions/src/api/experimental/auth.ts
@@ -2,7 +2,12 @@ import { extensionPort } from "../../util/comlink";
 import * as jose from "jose";
 import { polyfillEd25519 } from "../../polyfills/ed25519";
 
-polyfillEd25519();
+const success = polyfillEd25519();
+if (!success) {
+  console.warn(
+    "Failed to polyfill ed25519: crypto.subtle is not available in the environment. This will cause issues with the auth API."
+  );
+}
 
 /**
  * Returns a unique JWT token that can be used to verify that an extension has been loaded on Replit by a particular user

--- a/modules/extensions/src/api/experimental/auth.ts
+++ b/modules/extensions/src/api/experimental/auth.ts
@@ -1,5 +1,9 @@
 import { extensionPort } from "../../util/comlink";
 import * as jose from "jose";
+import { Ed25519Algorithm, polyfillEd25519, ponyfillEd25519 } from "@yoursunny/webcrypto-ed25519";
+
+polyfillEd25519();
+window.jose = jose;
 
 /**
  * Returns a unique JWT token that can be used to verify that an extension has been loaded on Replit by a particular user
@@ -31,6 +35,8 @@ export async function verifyAuthToken(token: string) {
   );
 
   const { value: publicKey } = await res.json();
+
+  console.log(publicKey);
 
   const importedPublicKey = await jose.importSPKI(publicKey, "RS256");
 

--- a/modules/extensions/src/api/experimental/auth.ts
+++ b/modules/extensions/src/api/experimental/auth.ts
@@ -30,7 +30,7 @@ export async function verifyAuthToken(token: string) {
     `https://replit.com/data/extensions/publicKey/${tokenHeaders.kid}`
   );
 
-  const publicKey = await res.text();
+  const { value: publicKey } = await res.json();
 
   const importedPublicKey = await jose.importSPKI(publicKey, "RS256");
 

--- a/modules/extensions/src/api/experimental/auth.ts
+++ b/modules/extensions/src/api/experimental/auth.ts
@@ -1,9 +1,8 @@
 import { extensionPort } from "../../util/comlink";
 import * as jose from "jose";
-import { Ed25519Algorithm, polyfillEd25519, ponyfillEd25519 } from "@yoursunny/webcrypto-ed25519";
+import { polyfillEd25519 } from "../../polyfills/ed25519";
 
 polyfillEd25519();
-window.jose = jose;
 
 /**
  * Returns a unique JWT token that can be used to verify that an extension has been loaded on Replit by a particular user
@@ -36,9 +35,7 @@ export async function verifyAuthToken(token: string) {
 
   const { value: publicKey } = await res.json();
 
-  console.log(publicKey);
-
-  const importedPublicKey = await jose.importSPKI(publicKey, "RS256");
+  const importedPublicKey = await jose.importSPKI(publicKey, "EdDSA");
 
   const decodedToken = await jose.jwtVerify(token, importedPublicKey);
 

--- a/modules/extensions/src/index.ts
+++ b/modules/extensions/src/index.ts
@@ -52,7 +52,6 @@ export async function init(args?: ReplitInitArgs): Promise<ReplitInitOutput> {
 
   try {
     if (window) {
-      window.replit = replit;
       await windowIsReady();
     }
 

--- a/modules/extensions/src/index.ts
+++ b/modules/extensions/src/index.ts
@@ -6,7 +6,7 @@ export * from "./api";
 export * from "./util/log";
 export { extensionPort, proxy };
 export * from "./types";
-import * as replit from '.';
+import * as replit from ".";
 
 export { version } from "../package.json";
 

--- a/modules/extensions/src/index.ts
+++ b/modules/extensions/src/index.ts
@@ -6,6 +6,7 @@ export * from "./api";
 export * from "./util/log";
 export { extensionPort, proxy };
 export * from "./types";
+import * as replit from '.';
 
 export { version } from "../package.json";
 
@@ -51,6 +52,7 @@ export async function init(args?: ReplitInitArgs): Promise<ReplitInitOutput> {
 
   try {
     if (window) {
+      window.replit = replit;
       await windowIsReady();
     }
 

--- a/modules/extensions/src/polyfills/ed25519.ts
+++ b/modules/extensions/src/polyfills/ed25519.ts
@@ -239,6 +239,8 @@ interface Ponyfill extends Record<keyof SubtleCrypto, Function> {}
 
 export function ponyfillEd25519(subtle = crypto.subtle): SubtleCrypto | null {
   if (!subtle) {
+    // This is for JSDOM compatibility, since that environment doesn't support the crypto.subtle API at all.
+    // It shouldn't happen on a real browser
     console.warn(`polyfill ed25519: crypto.subtle is not available`);
     return null;
   }

--- a/modules/extensions/src/polyfills/ed25519.ts
+++ b/modules/extensions/src/polyfills/ed25519.ts
@@ -237,13 +237,26 @@ class Ponyfill implements Record<keyof SubtleCrypto, Function> {
 }
 interface Ponyfill extends Record<keyof SubtleCrypto, Function> {}
 
-export function ponyfillEd25519(subtle = crypto.subtle): SubtleCrypto {
+export function ponyfillEd25519(subtle = crypto.subtle): SubtleCrypto | null {
+  if (!subtle) {
+    console.warn(`polyfill ed25519: crypto.subtle is not available`);
+    return null;
+  }
+
   return new Ponyfill(subtle) as unknown as SubtleCrypto;
 }
 
-export function polyfillEd25519(): void {
+export function polyfillEd25519(): boolean {
+  const ponyfill = ponyfillEd25519();
+
+  if (!ponyfill) {
+    return false;
+  }
+
   Object.defineProperty(globalThis.crypto, "subtle", {
-    value: ponyfillEd25519(),
+    value: ponyfill,
     configurable: true,
   });
+
+  return true;
 }

--- a/modules/extensions/src/polyfills/ed25519.ts
+++ b/modules/extensions/src/polyfills/ed25519.ts
@@ -1,0 +1,249 @@
+/**
+ * This is a polyfill for ed25519 support in the browser, which is currently not available as part of the
+ * WebCrypto API. The polyfill code is vendored from https://www.npmjs.com/package/@yoursunny/webcrypto-ed25519,
+ * and modified to use a modern and more secure version of @noble/curves.
+ */
+
+import { ed25519 as ed } from "@noble/curves/ed25519";
+import { bytesToHex } from "@noble/curves/abstract/utils";
+import * as asn1 from "@root/asn1";
+// @ts-expect-error no typing
+import { toBase64Url as b64encode, toBuffer as b64decode } from "b64u-lite";
+
+export const C = {
+  wicgAlgorithm: "Ed25519",
+  nodeAlgorithm: "NODE-ED25519",
+  nodeNamedCurve: "NODE-ED25519",
+  kty: "OKP",
+  crv: "Ed25519",
+  oid: "2B6570".toLowerCase(),
+};
+
+export function isEd25519Algorithm(a: any) {
+  return (
+    a === C.wicgAlgorithm ||
+    a === C.nodeAlgorithm ||
+    a.name === C.wicgAlgorithm ||
+    (a.name === C.nodeAlgorithm && a.namedCurve === C.nodeNamedCurve)
+  );
+}
+
+export const Ed25519Algorithm: KeyAlgorithm = {
+  name: C.wicgAlgorithm,
+};
+
+function asUint8Array(b: BufferSource): Uint8Array {
+  if (b instanceof Uint8Array) {
+    return b;
+  }
+  if (b instanceof ArrayBuffer) {
+    return new Uint8Array(b);
+  }
+  return new Uint8Array(b.buffer, b.byteOffset, b.byteLength);
+}
+
+function asArrayBuffer(b: Uint8Array): ArrayBuffer {
+  if (b.byteLength === b.buffer.byteLength) {
+    return b.buffer;
+  }
+  return b.buffer.slice(b.byteOffset, b.byteLength);
+}
+
+const slot = "8d9df0f7-1363-4d2c-8152-ce4ed78f27d8";
+
+interface Ed25519CryptoKey extends CryptoKey {
+  [slot]: Uint8Array;
+}
+
+class Ponyfill implements Record<keyof SubtleCrypto, Function> {
+  constructor(private readonly super_: SubtleCrypto) {
+    this.orig_ = {} as any;
+    for (const method of [
+      "generateKey",
+      "exportKey",
+      "importKey",
+      "encrypt",
+      "decrypt",
+      "wrapKey",
+      "unwrapKey",
+      "deriveBits",
+      "deriveKey",
+      "sign",
+      "verify",
+      "digest",
+    ] as const) {
+      if (this[method]) {
+        this.orig_[method] = super_[method];
+      } else {
+        this[method] = super_[method].bind(super_) as any;
+      }
+    }
+  }
+
+  private readonly orig_: Record<keyof SubtleCrypto, Function>;
+
+  public async generateKey(
+    algorithm: KeyAlgorithm,
+    extractable: boolean,
+    keyUsages: Iterable<KeyUsage>
+  ): Promise<CryptoKeyPair> {
+    if (isEd25519Algorithm(algorithm)) {
+      const pvt = ed.utils.randomPrivateKey();
+      const pub = await ed.getPublicKey(pvt);
+
+      const usages = Array.from(keyUsages);
+      const privateKey: Ed25519CryptoKey = {
+        algorithm,
+        extractable,
+        type: "private",
+        usages,
+        [slot]: pvt,
+      };
+      const publicKey: Ed25519CryptoKey = {
+        algorithm,
+        extractable: true,
+        type: "public",
+        usages,
+        [slot]: pub,
+      };
+      return { privateKey, publicKey };
+    }
+    return this.orig_.generateKey.apply(this.super_, arguments);
+  }
+
+  public async exportKey(
+    format: KeyFormat,
+    key: CryptoKey
+  ): Promise<JsonWebKey | ArrayBuffer> {
+    if (isEd25519Algorithm(key.algorithm) && key.extractable) {
+      const raw = (key as Ed25519CryptoKey)[slot];
+      switch (format) {
+        case "jwk": {
+          const jwk: JsonWebKey = {
+            kty: C.kty,
+            crv: C.crv,
+          };
+          if (key.type === "public") {
+            jwk.x = b64encode(raw);
+          } else {
+            jwk.d = b64encode(raw);
+            jwk.x = b64encode(await ed.getPublicKey(raw));
+          }
+          return jwk;
+        }
+        case "spki": {
+          return asArrayBuffer(
+            asn1.pack([
+              "30",
+              [
+                ["30", [["06", "2B6570"]]],
+                ["03", raw],
+              ],
+            ])
+          );
+        }
+      }
+    }
+    return this.orig_.exportKey.apply(this.super_, arguments);
+  }
+
+  public async importKey(
+    format: KeyFormat,
+    keyData: JsonWebKey | BufferSource,
+    algorithm: Algorithm,
+    extractable: boolean,
+    keyUsages: Iterable<KeyUsage>
+  ): Promise<CryptoKey> {
+    if (isEd25519Algorithm(algorithm)) {
+      const usages = Array.from(keyUsages);
+      switch (format) {
+        case "jwk": {
+          const jwk = keyData as JsonWebKey;
+          if (jwk.kty !== C.kty || jwk.crv !== C.crv || !jwk.x) {
+            break;
+          }
+
+          const key: Ed25519CryptoKey = {
+            algorithm,
+            extractable,
+            type: jwk.d ? "private" : "public",
+            usages,
+            [slot]: b64decode(jwk.d ?? jwk.x),
+          };
+          return key;
+        }
+        case "spki": {
+          const der = asn1.parseVerbose(asUint8Array(keyData as BufferSource));
+          const algo = der.children?.[0]?.children?.[0]?.value;
+          const raw = der.children?.[1]?.value;
+          if (
+            !(algo instanceof Uint8Array) ||
+            bytesToHex(algo) !== C.oid ||
+            !(raw instanceof Uint8Array)
+          ) {
+            break;
+          }
+          const key: Ed25519CryptoKey = {
+            algorithm,
+            extractable: true,
+            type: "public",
+            usages,
+            [slot]: raw,
+          };
+          return key;
+        }
+      }
+    }
+    return this.orig_.importKey.apply(this.super_, arguments);
+  }
+
+  public async sign(
+    algorithm: AlgorithmIdentifier,
+    key: CryptoKey,
+    data: BufferSource
+  ): Promise<ArrayBuffer> {
+    if (
+      isEd25519Algorithm(algorithm) &&
+      isEd25519Algorithm(key.algorithm) &&
+      key.type === "private" &&
+      key.usages.includes("sign")
+    ) {
+      return asArrayBuffer(
+        await ed.sign(asUint8Array(data), (key as Ed25519CryptoKey)[slot])
+      );
+    }
+    return this.orig_.sign.apply(this.super_, arguments);
+  }
+
+  public async verify(
+    algorithm: AlgorithmIdentifier,
+    key: CryptoKey,
+    signature: BufferSource,
+    data: BufferSource
+  ): Promise<boolean> {
+    if (
+      isEd25519Algorithm(algorithm) &&
+      isEd25519Algorithm(key.algorithm) &&
+      key.type === "public" &&
+      key.usages.includes("verify")
+    ) {
+      const s = asUint8Array(signature);
+      const m = asUint8Array(data);
+      const p = (key as Ed25519CryptoKey)[slot];
+      return ed.verify(s, m, p);
+    }
+    return this.orig_.verify.apply(this.super_, arguments);
+  }
+}
+interface Ponyfill extends Record<keyof SubtleCrypto, Function> {}
+
+export function ponyfillEd25519(subtle = crypto.subtle): SubtleCrypto {
+  return new Ponyfill(subtle) as unknown as SubtleCrypto;
+}
+
+export function polyfillEd25519(): void {
+  Object.defineProperty(globalThis.crypto, "subtle", {
+    value: ponyfillEd25519(),
+    configurable: true,
+  });
+}

--- a/package.json
+++ b/package.json
@@ -49,5 +49,10 @@
     "typedoc": "^0.23.21",
     "typescript": "^4.9.3",
     "vite": "^4.2.1"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "jose@4.14.4": "patches/jose@4.14.4.patch"
+    }
   }
 }

--- a/patches/jose@4.14.4.patch
+++ b/patches/jose@4.14.4.patch
@@ -1,16 +1,11 @@
-diff --git a/dist/browser/runtime/is_key_like.js b/dist/browser/runtime/is_key_like.js
-index 8d35fdc84c4f2642dd144004a8faffca7efba578..cc8a9cd40940b65ab8c75bb854ab6432d70cf922 100644
---- a/dist/browser/runtime/is_key_like.js
-+++ b/dist/browser/runtime/is_key_like.js
-@@ -1,5 +1,18 @@
--import { isCryptoKey } from './webcrypto.js';
-+import { isCryptoKey } from "./webcrypto.js";
- export default (key) => {
--    return isCryptoKey(key);
-+  if (isCryptoKey(key)) {
-+    return true;
-+  }
-+
+diff --git a/dist/browser/runtime/webcrypto.js b/dist/browser/runtime/webcrypto.js
+index f9e1e915390c4ebf7cf0581f4b183cae253ae402..b0b94ae6ae35f36fb187b1d316d5a4eab880531d 100644
+--- a/dist/browser/runtime/webcrypto.js
++++ b/dist/browser/runtime/webcrypto.js
+@@ -1,2 +1,13 @@
+ export default crypto;
+-export const isCryptoKey = (key) => key instanceof CryptoKey;
++export const isCryptoKey = (key) => {
 +  if (
 +    "type" in key &&
 +    "extractable" in key &&
@@ -20,7 +15,5 @@ index 8d35fdc84c4f2642dd144004a8faffca7efba578..cc8a9cd40940b65ab8c75bb854ab6432
 +    return true;
 +  }
 +
-+  return false;
- };
--export const types = ['CryptoKey'];
-+export const types = ["CryptoKey"];
++  return key instanceof CryptoKey;
++};

--- a/patches/jose@4.14.4.patch
+++ b/patches/jose@4.14.4.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/browser/runtime/is_key_like.js b/dist/browser/runtime/is_key_like.js
+index 8d35fdc84c4f2642dd144004a8faffca7efba578..cc8a9cd40940b65ab8c75bb854ab6432d70cf922 100644
+--- a/dist/browser/runtime/is_key_like.js
++++ b/dist/browser/runtime/is_key_like.js
+@@ -1,5 +1,18 @@
+-import { isCryptoKey } from './webcrypto.js';
++import { isCryptoKey } from "./webcrypto.js";
+ export default (key) => {
+-    return isCryptoKey(key);
++  if (isCryptoKey(key)) {
++    return true;
++  }
++
++  if (
++    "type" in key &&
++    "extractable" in key &&
++    "algorithm" in key &&
++    "usages" in key
++  ) {
++    return true;
++  }
++
++  return false;
+ };
+-export const types = ['CryptoKey'];
++export const types = ["CryptoKey"];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: 5.4
 
 patchedDependencies:
   jose@4.14.4:
-    hash: o2ydbihrvtugezt3xwu4stgz3i
+    hash: huvwuedo4gdsbrz3c6b3a2uxty
     path: patches/jose@4.14.4.patch
 
 importers:
@@ -69,7 +69,7 @@ importers:
       '@replit/extensions-react': link:../extensions-react
       '@vitejs/plugin-react': 4.0.0_vite@4.3.5
       chai: 4.3.7
-      jose: 4.14.4_o2ydbihrvtugezt3xwu4stgz3i
+      jose: 4.14.4_huvwuedo4gdsbrz3c6b3a2uxty
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-feather: 2.0.10_react@18.2.0
@@ -93,7 +93,7 @@ importers:
     dependencies:
       '@codemirror/state': 6.2.0
       comlink: 4.4.1
-      jose: 4.14.4_o2ydbihrvtugezt3xwu4stgz3i
+      jose: 4.14.4_huvwuedo4gdsbrz3c6b3a2uxty
     devDependencies:
       esbuild: 0.15.18
       prettier: 2.8.8
@@ -4074,7 +4074,7 @@ packages:
       - ts-node
     dev: true
 
-  /jose/4.14.4_o2ydbihrvtugezt3xwu4stgz3i:
+  /jose/4.14.4_huvwuedo4gdsbrz3c6b3a2uxty:
     resolution: {integrity: sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==}
     dev: false
     patched: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,6 @@ importers:
       '@noble/curves': ^1.0.0
       '@root/asn1': ^1.0.0
       '@types/root__asn1': ^1.0.2
-      '@yoursunny/webcrypto-ed25519': ^0.0.20221020
       b64u-lite: ^1.1.0
       comlink: ^4.3.1
       esbuild: ^0.15.18
@@ -99,7 +98,6 @@ importers:
       '@codemirror/state': 6.2.0
       '@noble/curves': 1.0.0
       '@root/asn1': 1.0.0
-      '@yoursunny/webcrypto-ed25519': 0.0.20221020
       b64u-lite: 1.1.0
       comlink: 4.4.1
       jose: 4.14.4_huvwuedo4gdsbrz3c6b3a2uxty
@@ -1203,10 +1201,6 @@ packages:
       '@noble/hashes': 1.3.0
     dev: false
 
-  /@noble/ed25519/1.7.3:
-    resolution: {integrity: sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==}
-    dev: false
-
   /@noble/hashes/1.3.0:
     resolution: {integrity: sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==}
     dev: false
@@ -1391,6 +1385,7 @@ packages:
 
   /@types/root__asn1/1.0.2:
     resolution: {integrity: sha512-bsmhfl1SAnk2cD82UfWwFhtmh8zAkyeBsgnApiOkkdPRgcbA3odlSudr9RQN9ZxR5upxrRX7cg6oEjmEpsa/5A==}
+    dev: true
 
   /@types/scheduler/0.16.3:
     resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
@@ -1442,22 +1437,6 @@ packages:
       vite: 4.3.5_@types+node@20.2.3
     transitivePeerDependencies:
       - supports-color
-
-  /@yoursunny/asn1/0.0.20200718:
-    resolution: {integrity: sha512-PFM+/rP/GHm1i37NlbZp8+piK2WVzEbq8rai71dlNN+njF3gaUVKDPgmTRIs18j99XeM/n71NFiaGr4QPbHF3g==}
-    dependencies:
-      '@root/encoding': 1.0.1
-      '@types/root__asn1': 1.0.2
-    dev: false
-
-  /@yoursunny/webcrypto-ed25519/0.0.20221020:
-    resolution: {integrity: sha512-hXgbBAFYOOLmIlx5eOR35ISItfcAoEp66an9wptljm5JQ8MVU3nBuWdfSd+p8Cp2+JR5Dv8SIl2vLeOtib0jIQ==}
-    dependencies:
-      '@noble/ed25519': 1.7.3
-      '@yoursunny/asn1': 0.0.20200718
-      b64u-lite: 1.1.0
-      compare-versions: 5.0.3
-    dev: false
 
   /abab/2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
@@ -2086,10 +2065,6 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
     dev: true
-
-  /compare-versions/5.0.3:
-    resolution: {integrity: sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==}
-    dev: false
 
   /component-emitter/1.3.0:
     resolution: {integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,7 @@ importers:
   modules/extensions:
     specifiers:
       '@codemirror/state': ^6.2.0
+      '@yoursunny/webcrypto-ed25519': ^0.0.20221020
       comlink: ^4.3.1
       esbuild: ^0.15.18
       jose: ^4.14.4
@@ -92,6 +93,7 @@ importers:
       typescript: ^4.9.3
     dependencies:
       '@codemirror/state': 6.2.0
+      '@yoursunny/webcrypto-ed25519': 0.0.20221020
       comlink: 4.4.1
       jose: 4.14.4_huvwuedo4gdsbrz3c6b3a2uxty
     devDependencies:
@@ -1187,6 +1189,10 @@ packages:
       read-yaml-file: 1.1.0
     dev: true
 
+  /@noble/ed25519/1.7.3:
+    resolution: {integrity: sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==}
+    dev: false
+
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1207,6 +1213,10 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
     dev: true
+
+  /@root/encoding/1.0.1:
+    resolution: {integrity: sha512-OaEub02ufoU038gy6bsNHQOjIn8nUjGiLcaRmJ40IUykneJkIW5fxDqKxQx48cszuNflYldsJLPPXCrGfHs8yQ==}
+    dev: false
 
   /@sinclair/typebox/0.25.24:
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
@@ -1355,6 +1365,10 @@ packages:
       '@types/scheduler': 0.16.3
       csstype: 3.1.2
 
+  /@types/root__asn1/1.0.2:
+    resolution: {integrity: sha512-bsmhfl1SAnk2cD82UfWwFhtmh8zAkyeBsgnApiOkkdPRgcbA3odlSudr9RQN9ZxR5upxrRX7cg6oEjmEpsa/5A==}
+    dev: false
+
   /@types/scheduler/0.16.3:
     resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
 
@@ -1405,6 +1419,22 @@ packages:
       vite: 4.3.5_@types+node@20.2.3
     transitivePeerDependencies:
       - supports-color
+
+  /@yoursunny/asn1/0.0.20200718:
+    resolution: {integrity: sha512-PFM+/rP/GHm1i37NlbZp8+piK2WVzEbq8rai71dlNN+njF3gaUVKDPgmTRIs18j99XeM/n71NFiaGr4QPbHF3g==}
+    dependencies:
+      '@root/encoding': 1.0.1
+      '@types/root__asn1': 1.0.2
+    dev: false
+
+  /@yoursunny/webcrypto-ed25519/0.0.20221020:
+    resolution: {integrity: sha512-hXgbBAFYOOLmIlx5eOR35ISItfcAoEp66an9wptljm5JQ8MVU3nBuWdfSd+p8Cp2+JR5Dv8SIl2vLeOtib0jIQ==}
+    dependencies:
+      '@noble/ed25519': 1.7.3
+      '@yoursunny/asn1': 0.0.20200718
+      b64u-lite: 1.1.0
+      compare-versions: 5.0.3
+    dev: false
 
   /abab/2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
@@ -1580,6 +1610,18 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /b64-lite/1.4.0:
+    resolution: {integrity: sha512-aHe97M7DXt+dkpa8fHlCcm1CnskAHrJqEfMI0KN7dwqlzml/aUe1AGt6lk51HzrSfVD67xOso84sOpr+0wIe2w==}
+    dependencies:
+      base-64: 0.1.0
+    dev: false
+
+  /b64u-lite/1.1.0:
+    resolution: {integrity: sha512-929qWGDVCRph7gQVTC6koHqQIpF4vtVaSbwLltFQo44B1bYUquALswZdBKFfrJCPEnsCOvWkJsPdQYZ/Ukhw8A==}
+    dependencies:
+      b64-lite: 1.4.0
+    dev: false
+
   /babel-jest/26.6.3_@babel+core@7.21.8:
     resolution: {integrity: sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==}
     engines: {node: '>= 10.14.2'}
@@ -1695,6 +1737,10 @@ packages:
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
+
+  /base-64/0.1.0:
+    resolution: {integrity: sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==}
+    dev: false
 
   /base/0.11.2:
     resolution: {integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==}
@@ -2017,6 +2063,10 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
     dev: true
+
+  /compare-versions/5.0.3:
+    resolution: {integrity: sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==}
+    dev: false
 
   /component-emitter/1.3.0:
     resolution: {integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,7 +83,11 @@ importers:
   modules/extensions:
     specifiers:
       '@codemirror/state': ^6.2.0
+      '@noble/curves': ^1.0.0
+      '@root/asn1': ^1.0.0
+      '@types/root__asn1': ^1.0.2
       '@yoursunny/webcrypto-ed25519': ^0.0.20221020
+      b64u-lite: ^1.1.0
       comlink: ^4.3.1
       esbuild: ^0.15.18
       jose: ^4.14.4
@@ -93,10 +97,14 @@ importers:
       typescript: ^4.9.3
     dependencies:
       '@codemirror/state': 6.2.0
+      '@noble/curves': 1.0.0
+      '@root/asn1': 1.0.0
       '@yoursunny/webcrypto-ed25519': 0.0.20221020
+      b64u-lite: 1.1.0
       comlink: 4.4.1
       jose: 4.14.4_huvwuedo4gdsbrz3c6b3a2uxty
     devDependencies:
+      '@types/root__asn1': 1.0.2
       esbuild: 0.15.18
       prettier: 2.8.8
       tsup: 6.7.0_typescript@4.9.5
@@ -1189,8 +1197,18 @@ packages:
       read-yaml-file: 1.1.0
     dev: true
 
+  /@noble/curves/1.0.0:
+    resolution: {integrity: sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==}
+    dependencies:
+      '@noble/hashes': 1.3.0
+    dev: false
+
   /@noble/ed25519/1.7.3:
     resolution: {integrity: sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==}
+    dev: false
+
+  /@noble/hashes/1.3.0:
+    resolution: {integrity: sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==}
     dev: false
 
   /@nodelib/fs.scandir/2.1.5:
@@ -1213,6 +1231,12 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
     dev: true
+
+  /@root/asn1/1.0.0:
+    resolution: {integrity: sha512-0lfZNuOULKJDJmdIkP8V9RnbV3XaK6PAHD3swnFy4tZwtlMDzLKoM/dfNad7ut8Hu3r91wy9uK0WA/9zym5mig==}
+    dependencies:
+      '@root/encoding': 1.0.1
+    dev: false
 
   /@root/encoding/1.0.1:
     resolution: {integrity: sha512-OaEub02ufoU038gy6bsNHQOjIn8nUjGiLcaRmJ40IUykneJkIW5fxDqKxQx48cszuNflYldsJLPPXCrGfHs8yQ==}
@@ -1367,7 +1391,6 @@ packages:
 
   /@types/root__asn1/1.0.2:
     resolution: {integrity: sha512-bsmhfl1SAnk2cD82UfWwFhtmh8zAkyeBsgnApiOkkdPRgcbA3odlSudr9RQN9ZxR5upxrRX7cg6oEjmEpsa/5A==}
-    dev: false
 
   /@types/scheduler/0.16.3:
     resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,10 @@
 lockfileVersion: 5.4
 
+patchedDependencies:
+  jose@4.14.4:
+    hash: o2ydbihrvtugezt3xwu4stgz3i
+    path: patches/jose@4.14.4.patch
+
 importers:
 
   .:
@@ -64,7 +69,7 @@ importers:
       '@replit/extensions-react': link:../extensions-react
       '@vitejs/plugin-react': 4.0.0_vite@4.3.5
       chai: 4.3.7
-      jose: 4.14.4
+      jose: 4.14.4_o2ydbihrvtugezt3xwu4stgz3i
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-feather: 2.0.10_react@18.2.0
@@ -88,7 +93,7 @@ importers:
     dependencies:
       '@codemirror/state': 6.2.0
       comlink: 4.4.1
-      jose: 4.14.4
+      jose: 4.14.4_o2ydbihrvtugezt3xwu4stgz3i
     devDependencies:
       esbuild: 0.15.18
       prettier: 2.8.8
@@ -1325,7 +1330,6 @@ packages:
 
   /@types/node/20.2.3:
     resolution: {integrity: sha512-pg9d0yC4rVNWQzX8U7xb4olIOFuuVL9za3bzMT2pu2SU0SNEi66i2qrvhE2qt0HvkhuCaWJu7pLNOt/Pj8BIrw==}
-    dev: true
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -1398,7 +1402,7 @@ packages:
       '@babel/plugin-transform-react-jsx-self': 7.21.0_@babel+core@7.21.8
       '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.21.8
       react-refresh: 0.14.0
-      vite: 4.3.5
+      vite: 4.3.5_@types+node@20.2.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4070,9 +4074,10 @@ packages:
       - ts-node
     dev: true
 
-  /jose/4.14.4:
+  /jose/4.14.4_o2ydbihrvtugezt3xwu4stgz3i:
     resolution: {integrity: sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==}
     dev: false
+    patched: true
 
   /joycon/3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -5865,6 +5870,7 @@ packages:
       rollup: 3.21.5
     optionalDependencies:
       fsevents: 2.3.2
+    dev: false
 
   /vite/4.3.5_@types+node@20.2.3:
     resolution: {integrity: sha512-0gEnL9wiRFxgz40o/i/eTBwm+NEbpUeTWhzKrZDSdKm6nplj+z4lKz8ANDgildxHm47Vg8EUia0aicKbawUVVA==}
@@ -5897,7 +5903,6 @@ packages:
       rollup: 3.21.5
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /vscode-oniguruma/1.7.0:
     resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}


### PR DESCRIPTION
- We switched to ed25519 but the browser support for that is pretty limited, so we're using a library to polyfill SubtleCrypto behavior for `jose`.

- `jose` itself needed a patch to accept these keys made by our polyfill

- the auth endpoint now returns a result type instead of just the result