### PR TITLE
Verification in non-browser enviroments

### DIFF
--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@codemirror/state": "^6.2.0",
     "@noble/curves": "^1.0.0",
+		"@replit/node-fetch": "^3.1.0",
     "@root/asn1": "^1.0.0",
     "b64u-lite": "^1.1.0",
     "comlink": "^4.3.1",

--- a/modules/extensions/src/api/experimental/auth.ts
+++ b/modules/extensions/src/api/experimental/auth.ts
@@ -3,11 +3,13 @@ import * as jose from "jose";
 import { polyfillEd25519 } from "../../polyfills/ed25519";
 import { AuthenticateResult, JWTVerifyResult } from "../../types";
 
-const success = polyfillEd25519();
-if (!success) {
-  console.warn(
-    "Failed to polyfill ed25519: crypto.subtle is not available in the environment. This will cause issues with the auth API."
-  );
+if(typeof window !== "undefined") {
+	const success = polyfillEd25519();
+	if (!success) {
+	  console.warn(
+	    "Failed to polyfill ed25519: crypto.subtle is not available in the environment. This will cause issues with the auth API."
+	  );
+	}
 }
 
 /**
@@ -35,9 +37,25 @@ export async function verifyAuthToken(token: string): Promise<JWTVerifyResult> {
     throw new Error("Expected `kid` to be defined");
   }
 
-  const res = await fetch(
-    `https://replit.com/data/extensions/publicKey/${tokenHeaders.kid}`
-  );
+  let res: Response;
+	
+	if(typeof window !== "undefined") {
+		res = await fetch(
+  	  `https://replit.com/data/extensions/publicKey/${tokenHeaders.kid}`
+  	);
+	} else {
+		res = await fetch(
+      `https://replit.com/data/extensions/publicKey/${tokenHeaders.kid}`,
+        {
+          headers: {
+            "Referrer": "https://replit.com/",
+            "Origin": "https://replit.com/",
+            "X-Requested-With": "XMLHttpRequest",
+            "User-Agent": "Mozilla/5.0 (@replit/extensions)",
+          },
+        }
+    );
+	}
 
   const { ok, value: publicKey } = await res.json();
 

--- a/modules/extensions/src/api/experimental/auth.ts
+++ b/modules/extensions/src/api/experimental/auth.ts
@@ -3,13 +3,13 @@ import * as jose from "jose";
 import { polyfillEd25519 } from "../../polyfills/ed25519";
 import { AuthenticateResult, JWTVerifyResult } from "../../types";
 
-if(typeof window !== "undefined") {
-	const success = polyfillEd25519();
-	if (!success) {
-	  console.warn(
-	    "Failed to polyfill ed25519: crypto.subtle is not available in the environment. This will cause issues with the auth API."
-	  );
-	}
+if (typeof window !== "undefined") {
+  const success = polyfillEd25519();
+  if (!success) {
+    console.warn(
+      "Failed to polyfill ed25519: crypto.subtle is not available in the environment. This will cause issues with the auth API."
+    );
+  }
 }
 
 /**
@@ -38,24 +38,25 @@ export async function verifyAuthToken(token: string): Promise<JWTVerifyResult> {
   }
 
   let res: Response;
-	
-	if(typeof window !== "undefined") {
-		res = await fetch(
-  	  `https://replit.com/data/extensions/publicKey/${tokenHeaders.kid}`
-  	);
-	} else {
-		res = await fetch(
-      `https://replit.com/data/extensions/publicKey/${tokenHeaders.kid}`,
-        {
-          headers: {
-            "Referrer": "https://replit.com/",
-            "Origin": "https://replit.com/",
-            "X-Requested-With": "XMLHttpRequest",
-            "User-Agent": "Mozilla/5.0 (@replit/extensions)",
-          },
-        }
+
+  if (typeof window !== "undefined") {
+    res = await fetch(
+      `https://replit.com/data/extensions/publicKey/${tokenHeaders.kid}`
     );
-	}
+  } else {
+    const fetch = await import("@replit/node-fetch");
+    res = await fetch(
+      `https://replit.com/data/extensions/publicKey/${tokenHeaders.kid}`,
+      {
+        headers: {
+          Referrer: "https://replit.com/",
+          Origin: "https://replit.com/",
+          "X-Requested-With": "XMLHttpRequest",
+          "User-Agent": "Mozilla/5.0 (@replit/extensions)",
+        },
+      }
+    );
+  }
 
   const { ok, value: publicKey } = await res.json();
 

--- a/modules/extensions/src/api/experimental/auth.ts
+++ b/modules/extensions/src/api/experimental/auth.ts
@@ -45,7 +45,7 @@ export async function verifyAuthToken(token: string): Promise<JWTVerifyResult> {
     );
   } else {
     const fetch = await import("@replit/node-fetch");
-    res = await fetch(
+    res = (await fetch.default(
       `https://replit.com/data/extensions/publicKey/${tokenHeaders.kid}`,
       {
         headers: {
@@ -55,7 +55,7 @@ export async function verifyAuthToken(token: string): Promise<JWTVerifyResult> {
           "User-Agent": "Mozilla/5.0 (@replit/extensions)",
         },
       }
-    );
+    )) as Response;
   }
 
   const { ok, value: publicKey } = await res.json();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,7 @@ importers:
     specifiers:
       '@codemirror/state': ^6.2.0
       '@noble/curves': ^1.0.0
+      '@replit/node-fetch': ^3.1.0
       '@root/asn1': ^1.0.0
       '@types/root__asn1': ^1.0.2
       b64u-lite: ^1.1.0
@@ -97,6 +98,7 @@ importers:
     dependencies:
       '@codemirror/state': 6.2.0
       '@noble/curves': 1.0.0
+      '@replit/node-fetch': 3.1.0
       '@root/asn1': 1.0.0
       b64u-lite: 1.1.0
       comlink: 4.4.1
@@ -1225,6 +1227,14 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
     dev: true
+
+  /@replit/node-fetch/3.1.0:
+    resolution: {integrity: sha512-mHkDKYS3CjJ2UtFlxtOyvNjrFZ4hhSri8biuQ/BLtUyj39+JYI9TusZS24wqVCnIPdEhpVJGhilk1qyfqgCHLw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      formdata-polyfill: 4.0.10
+      web-streams-polyfill: 3.2.1
+    dev: false
 
   /@root/asn1/1.0.0:
     resolution: {integrity: sha512-0lfZNuOULKJDJmdIkP8V9RnbV3XaK6PAHD3swnFy4tZwtlMDzLKoM/dfNad7ut8Hu3r91wy9uK0WA/9zym5mig==}
@@ -2874,6 +2884,14 @@ packages:
       bser: 2.1.1
     dev: true
 
+  /fetch-blob/3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.2.1
+    dev: false
+
   /fill-range/4.0.0:
     resolution: {integrity: sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==}
     engines: {node: '>=0.10.0'}
@@ -2933,6 +2951,13 @@ packages:
       combined-stream: 1.0.8
       mime-types: 2.1.35
     dev: true
+
+  /formdata-polyfill/4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+    dependencies:
+      fetch-blob: 3.2.0
+    dev: false
 
   /fragment-cache/0.2.1:
     resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
@@ -4544,6 +4569,11 @@ packages:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: true
 
+  /node-domexception/1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    dev: false
+
   /node-int64/0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: true
@@ -5978,6 +6008,11 @@ packages:
     dependencies:
       defaults: 1.0.4
     dev: true
+
+  /web-streams-polyfill/3.2.1:
+    resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
+    engines: {node: '>= 8'}
+    dev: false
 
   /webidl-conversions/4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}


### PR DESCRIPTION
# Why?

The current verification (and general auth module) won't work in Node.js/server environments because we are attempting to polyfill ed25519 on `window.crypto` but in Node.js crypto is not a global variable (and regardless doesn't need to be polyfilled).

## Changes

- Only polyfill for crypto in a browser environment by checking if `typeof window !== "undefined"`