### PR TITLE
Fix return types of filesystem methods

### DIFF
--- a/modules/dev/src/utils/assertions.ts
+++ b/modules/dev/src/utils/assertions.ts
@@ -3,12 +3,12 @@ import { assert } from "chai";
 // Makes sure a file's contents is a string and that no errors have occured.
 export function assertFileContents(
   file:
-    | {
-        content: string;
-      }
-    | { error: string }
+    {
+      content: string | null;
+      error: string | null;
+    }
 ) {
-  if ("content" in file) {
+  if (file.content !== null) {
     assert.isString(file.content);
 
     return file.content;

--- a/modules/dev/src/utils/assertions.ts
+++ b/modules/dev/src/utils/assertions.ts
@@ -2,11 +2,10 @@ import { assert } from "chai";
 
 // Makes sure a file's contents is a string and that no errors have occured.
 export function assertFileContents(
-  file:
-    {
-      content: string | null;
-      error: string | null;
-    }
+  file: {
+    content: string | null;
+    error: string | null;
+  }
 ) {
   if (file.content !== null) {
     assert.isString(file.content);

--- a/modules/extensions/src/types/index.ts
+++ b/modules/extensions/src/types/index.ts
@@ -72,24 +72,20 @@ export type ExtensionPortAPI = {
   readFile: (
     path: string,
     encoding: "utf8" | "binary" | null
-  ) => Promise<
-    | { content: string }
-    | {
-        error: string;
-      }
-  >;
+  ) => Promise<{
+    content: string | null;
+    error: string | null;
+  }>;
   writeFile: (
     path: string,
     content: string | Blob
-  ) => Promise<
-    | { success: boolean }
-    | {
-        error: string;
-      }
-  >;
+  ) => Promise<{
+    success: boolean;
+    error: string | null;
+  }>;
   readDir: (path: string) => Promise<{
-    children: Array<DirectoryChildNode>;
-    error: string;
+    children: Array<DirectoryChildNode> | null;
+    error: string | null;
   }>;
   createDir: (path: string) => Promise<{
     success: boolean;


### PR DESCRIPTION
Fixed the types of objects returned from the `readFile`, `writeFile`, and `readDir` methods so they match what's actually returned