### PR TITLE
Fixed duplicate console patching

### DIFF
--- a/modules/extensions/src/index.ts
+++ b/modules/extensions/src/index.ts
@@ -2,12 +2,12 @@ import { HandshakeStatus, ReplitInitArgs, ReplitInitOutput } from "./types";
 import { extensionPort, proxy } from "./util/comlink";
 import { getHandshakeStatus, setHandshakeStatus } from "./util/handshake";
 export * from "./api";
-import * as debug from "./api/debug";
 export { extensionPort, proxy };
 export * from "./types";
 import * as replit from ".";
 
 import { version } from "../package.json";
+import { patchConsole } from "./util/patchConsole";
 
 export { version };
 
@@ -34,33 +34,6 @@ async function windowIsReady() {
 
     window.addEventListener("load", loadHandler);
   });
-}
-
-function patchConsole() {
-  const originalLog = console.log;
-  const originalWarn = console.warn;
-  const originalError = console.error;
-  const originalInfo = console.info;
-
-  console.log = (...args: any[]) => {
-    originalLog(...args);
-    debug.log(args[0], { args: args.slice(1) });
-  };
-
-  console.warn = (...args: any[]) => {
-    originalWarn(...args);
-    debug.warn(args[0], { args: args.slice(1) });
-  };
-
-  console.error = (...args: any[]) => {
-    originalError(...args);
-    debug.error(args[0], { args: args.slice(1) });
-  };
-
-  console.info = (...args: any[]) => {
-    originalInfo(...args);
-    debug.info(args[0], { args: args.slice(1) });
-  };
 }
 
 export async function init(args?: ReplitInitArgs): Promise<ReplitInitOutput> {

--- a/modules/extensions/src/util/patchConsole.ts
+++ b/modules/extensions/src/util/patchConsole.ts
@@ -1,0 +1,42 @@
+import * as debug from "../api/debug";
+
+const consoleIsPatchedSymbol = Symbol("consoleIsPatched");
+
+export function patchConsole() {
+  if (isConsolePatched()) {
+    return;
+  }
+
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  const originalInfo = console.info;
+
+  console.log = (...args: any[]) => {
+    originalLog(...args);
+    debug.log(args[0], { args: args.slice(1) });
+  };
+
+  console.warn = (...args: any[]) => {
+    originalWarn(...args);
+    debug.warn(args[0], { args: args.slice(1) });
+  };
+
+  console.error = (...args: any[]) => {
+    originalError(...args);
+    debug.error(args[0], { args: args.slice(1) });
+  };
+
+  console.info = (...args: any[]) => {
+    originalInfo(...args);
+    debug.info(args[0], { args: args.slice(1) });
+  };
+
+  // @ts-ignore
+  console[consoleIsPatchedSymbol] = true;
+}
+
+export function isConsolePatched() {
+  // @ts-ignore
+  return Boolean(console[consoleIsPatchedSymbol]);
+}


### PR DESCRIPTION
If you call replit.init() multiple times, we patch the console multiple times, which is annoying