### PR TITLE
[extensions] simplified command API invocation

### DIFF
--- a/modules/extensions/changelog.md
+++ b/modules/extensions/changelog.md
@@ -1,3 +1,7 @@
+## 1.10.0
+
+- Simplified commands API
+
 ## 1.9.0
 
 - Add commands API

--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/extensions",
-  "version": "1.9.0",
+  "version": "1.10.0-beta.0",
   "description": "The Replit Extensions client is a module that allows you to easily interact with the Workspace.",
   "types": "./src/index.ts",
   "exports": {

--- a/modules/extensions/src/api/experimental/commands.ts
+++ b/modules/extensions/src/api/experimental/commands.ts
@@ -1,6 +1,6 @@
 import { extensionPort } from "../../util/comlink";
-import { Command } from "../../commands";
+import { CommandProxy } from "../../commands";
 
-export function register(command: Command): void {
+export function register(command: CommandProxy): void {
   extensionPort.experimental.commands.registerCommand(command);
 }

--- a/modules/extensions/src/commands/index.ts
+++ b/modules/extensions/src/commands/index.ts
@@ -1,33 +1,96 @@
 import { proxy } from "../util/comlink";
 
 export type Data = Record<string, any>;
-export type Commands = () => Promise<Array<ReturnType<typeof Command>>>;
+export type CommandFnArgs = {
+  active: boolean;
+  search: string;
+  path: SerializableValue[];
+};
+export type CommandsFn = (
+  args: CommandFnArgs
+) => Promise<Array<ReturnType<typeof Command>>>;
 export type Run = () => Promise<void>;
 
+type SerializableValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | SerializableValue[]
+  | { [key: string]: SerializableValue };
+
 export type CommandArgs = {
-  data: Data;
-  commands?: Commands;
+  commands?: CommandsFn;
   run?: Run;
-};
+} & { [key: string]: SerializableValue };
 
-export function Command({ data, commands, run }: CommandArgs) {
-  let wsCmd: CommandArgs = {
-    data,
-  };
+/**
+ * This validates a command. We make sure that exactly one of `commands` or `run` is defined, and every other argument is serializable.
+ */
+function validateCommand(cmdArgs: unknown): asserts cmdArgs is CommandArgs {
+  // Make sure cmdArgs is object
+  if (typeof cmdArgs !== "object") {
+    throw new Error("Command arguments must be an object");
+  }
+  if (cmdArgs === null) {
+    throw new Error("Command arguments must not be null");
+  }
 
-  if (commands && run) {
+  // Make sure it contains `commands` or `run`
+  if (!("commands" in cmdArgs) && !("run" in cmdArgs)) {
+    throw new Error("One of `commands` or `run` must be defined");
+  }
+
+  // But not both
+  if (
+    "commands" in cmdArgs &&
+    cmdArgs.commands &&
+    "run" in cmdArgs &&
+    cmdArgs.run
+  ) {
     throw new Error("Only one of `commands` or `run` must be defined");
   }
 
-  if (commands) {
-    wsCmd.data.type = "context";
-    wsCmd.commands = async (...args) => {
-      return proxy(await commands(...args));
-    };
-  } else if (run) {
-    wsCmd.data.type = "action";
-    wsCmd.run = run;
+  // And when provided, they must always be a function
+  if ("commands" in cmdArgs && typeof cmdArgs.commands !== "function") {
+    throw new Error("`commands` must be a function");
   }
+
+  if ("run" in cmdArgs && typeof cmdArgs.run !== "function") {
+    throw new Error("`run` must be a function");
+  }
+
+  // Make sure all other arguments are serializable
+  for (let entry of Object.entries(cmdArgs)) {
+    if (entry[0] === "commands" || entry[0] === "run") {
+      continue;
+    }
+
+    try {
+      JSON.stringify({ [entry[0]]: entry[1] });
+    } catch (e) {
+      throw new Error(`Command argument '${entry[0]}' is not serializable`);
+    }
+  }
+}
+
+export function Command(cmdArgs: CommandArgs) {
+  validateCommand(cmdArgs);
+  const { commands, run, ...props } = cmdArgs;
+
+  let wsCmd = {
+    data: {
+      ...props,
+      type: commands ? "context" : "action",
+    },
+    commands: commands
+      ? async (args: CommandFnArgs) => {
+          return proxy(await commands(args));
+        }
+      : undefined,
+    run: run ? run : undefined,
+  };
 
   return proxy(wsCmd);
 }

--- a/modules/extensions/src/types/index.ts
+++ b/modules/extensions/src/types/index.ts
@@ -23,7 +23,7 @@ import {
 import { OnActiveFileChangeListener } from "./session";
 import Comlink from "comlink";
 import { Data } from "../api/debug";
-import { Command } from "../commands";
+import { Command, CommandProxy } from "../commands";
 
 export * from "./fs";
 export * from "./themes";
@@ -211,7 +211,7 @@ export type ExperimentalAPI = {
   };
 
   commands: {
-    registerCommand: (command: Command) => void;
+    registerCommand: (command: CommandProxy) => void;
   };
 };
 


### PR DESCRIPTION
## Why

Describing a command is very verbose at the moment. 

## What changed

- This simplifies it by removing the need to nest everything under `data`. Instead we add validation to make sure everything apart from `commands` and `run` is serializable. 
- I also improved the typing, so validation is done by the type system before code is even run (but there's still runtime validation in case people use this in a non javascript context or typechecking is disabled / fails)
- I added type docs

## Test

Here's an example invocation:


```typescript
await replit.experimental.commands.register(Command({
    id: 'example',
    label: 'Example command',
    contributions: ['commandbar'],
    commands: async () => {
      return [
        Command({
          label: 'nice',
          run: () => {}
        }),
      ]
    }
  }))
```