### PR TITLE
[extensions] added the nicer commands.add call

### DIFF
--- a/modules/extensions/src/api/experimental/commands.ts
+++ b/modules/extensions/src/api/experimental/commands.ts
@@ -1,6 +1,36 @@
 import { extensionPort } from "../../util/comlink";
-import { CommandProxy } from "../../commands";
+import { CreateCommand, CommandProxy, Command } from "../../commands";
 
 export function register(command: CommandProxy): void {
   extensionPort.experimental.commands.registerCommand(command);
+}
+
+export function registerCreate(
+  data: { commandId: string; contributions: Array<string> },
+  createCommand: CreateCommand
+): void {
+  extensionPort.experimental.commands.registerCreateCommand(
+    data,
+    createCommand
+  );
+}
+
+export function add({
+  id,
+  contributions,
+}: {
+  id: string;
+  contributions: Array<string>;
+}) {
+  const create = (cmdOrCreate: CommandProxy | CreateCommand) => {
+    if (typeof cmdOrCreate === "function") {
+      registerCreate({ commandId: id, contributions }, cmdOrCreate);
+    } else {
+      registerCreate({ commandId: id, contributions }, async () => ({
+        ...cmdOrCreate,
+      }));
+    }
+  };
+
+  return create;
 }

--- a/modules/extensions/src/api/experimental/commands.ts
+++ b/modules/extensions/src/api/experimental/commands.ts
@@ -19,12 +19,12 @@ interface AddCommandArgs {
   /**
    * The command's unique identifier. This is used to identify the command in Replit's command system
    */
-  id: string,
+  id: string;
 
   /**
    * The surfaces that this command should appear in. This is an array of strings
    */
-  contributions: Array<string>,
+  contributions: Array<string>;
 
   /**
    * A Command, or, a function that returns a Command.
@@ -32,11 +32,7 @@ interface AddCommandArgs {
   command: CommandProxy | CreateCommand;
 }
 
-export function add({
-  id,
-  contributions,
-  command,
-}: AddCommandArgs) {
+export function add({ id, contributions, command }: AddCommandArgs) {
   if (typeof command === "function") {
     registerCreate({ commandId: id, contributions }, command);
   } else {

--- a/modules/extensions/src/api/experimental/commands.ts
+++ b/modules/extensions/src/api/experimental/commands.ts
@@ -15,22 +15,33 @@ export function registerCreate(
   );
 }
 
+interface AddCommandArgs {
+  /**
+   * The command's unique identifier. This is used to identify the command in Replit's command system
+   */
+  id: string,
+
+  /**
+   * The surfaces that this command should appear in. This is an array of strings
+   */
+  contributions: Array<string>,
+
+  /**
+   * A Command, or, a function that returns a Command.
+   */
+  command: CommandProxy | CreateCommand;
+}
+
 export function add({
   id,
   contributions,
-}: {
-  id: string;
-  contributions: Array<string>;
-}) {
-  const create = (cmdOrCreate: CommandProxy | CreateCommand) => {
-    if (typeof cmdOrCreate === "function") {
-      registerCreate({ commandId: id, contributions }, cmdOrCreate);
-    } else {
-      registerCreate({ commandId: id, contributions }, async () => ({
-        ...cmdOrCreate,
-      }));
-    }
-  };
-
-  return create;
+  command,
+}: AddCommandArgs) {
+  if (typeof command === "function") {
+    registerCreate({ commandId: id, contributions }, command);
+  } else {
+    registerCreate({ commandId: id, contributions }, async () => ({
+      ...command,
+    }));
+  }
 }

--- a/modules/extensions/src/commands/index.ts
+++ b/modules/extensions/src/commands/index.ts
@@ -20,9 +20,12 @@ export type CommandFnArgs = {
    */
   path: SerializableValue[];
 };
+
 export type CommandsFn = (args: CommandFnArgs) => Promise<Array<CommandProxy>>;
 
-export type CreateCommand = (args: CommandFnArgs) => Promise<CommandProxy>;
+export type CreateCommand = (
+  args: CommandFnArgs
+) => CommandProxy | Promise<CommandProxy>;
 
 export type Run = () => any;
 

--- a/modules/extensions/src/types/index.ts
+++ b/modules/extensions/src/types/index.ts
@@ -23,7 +23,7 @@ import {
 import { OnActiveFileChangeListener } from "./session";
 import Comlink from "comlink";
 import { Data } from "../api/debug";
-import { Command, CommandProxy } from "../commands";
+import { CommandFnArgs, CommandProxy, CreateCommand } from "../commands";
 
 export * from "./fs";
 export * from "./themes";
@@ -212,6 +212,13 @@ export type ExperimentalAPI = {
 
   commands: {
     registerCommand: (command: CommandProxy) => void;
+    registerCreateCommand: (
+      data: {
+        commandId: string;
+        contributions: Array<string>;
+      },
+      create: CreateCommand
+    ) => void;
   };
 };
 


### PR DESCRIPTION
## Why

`register` and `registerCreate` sound... bureaucratic. We also want a single syntax for creating commands directly or via passing a function that creates a command. 

This is a wrapper on top of the registerCreateCommand API that does just that!


## What changed

- Added `add`. When you call `commands.add`, you first provide it with an id and a contribution point array, and it returns a curried function. That function can be called, either with a command, or a function that creates a command