### PR TITLE
[commands] provide command args directly

### DIFF
--- a/modules/extensions/src/api/experimental/commands.ts
+++ b/modules/extensions/src/api/experimental/commands.ts
@@ -1,5 +1,14 @@
 import { extensionPort } from "../../util/comlink";
-import { CreateCommand, CommandProxy, ContributionType, Command, CommandFnArgs, CommandSymbol, CommandArgs, isCommandProxy } from "../../commands";
+import {
+  CreateCommand,
+  CommandProxy,
+  ContributionType,
+  Command,
+  CommandFnArgs,
+  CommandSymbol,
+  CommandArgs,
+  isCommandProxy,
+} from "../../commands";
 
 export interface AddCommandArgs {
   /**
@@ -27,19 +36,24 @@ export interface AddCommandArgs {
  */
 export function add({ id, contributions, command }: AddCommandArgs) {
   if (typeof command === "function") {
-
     let createCommand = async (cmdFnArgs: CommandFnArgs) => {
       const cmd = await command(cmdFnArgs);
-      
+
       return isCommandProxy(cmd) ? cmd : Command(cmd);
     };
 
-    extensionPort.experimental.commands.registerCreateCommand({ commandId: id, contributions }, createCommand);
+    extensionPort.experimental.commands.registerCreateCommand(
+      { commandId: id, contributions },
+      createCommand
+    );
   } else {
     let createCommand = async () => {
       return isCommandProxy(command) ? command : Command(command);
     };
-    extensionPort.experimental.commands.registerCreateCommand({ commandId: id, contributions }, createCommand);
+    extensionPort.experimental.commands.registerCreateCommand(
+      { commandId: id, contributions },
+      createCommand
+    );
   }
 }
 

--- a/modules/extensions/src/api/experimental/commands.ts
+++ b/modules/extensions/src/api/experimental/commands.ts
@@ -39,6 +39,10 @@ export function add({ id, contributions, command }: AddCommandArgs) {
     let createCommand = async (cmdFnArgs: CommandFnArgs) => {
       const cmd = await command(cmdFnArgs);
 
+      if (!cmd) {
+        return null;
+      }
+
       return isCommandProxy(cmd) ? cmd : Command(cmd);
     };
 
@@ -71,8 +75,17 @@ export function registerCreate(
   data: { commandId: string; contributions: Array<string> },
   createCommand: CreateCommand
 ): void {
+
   extensionPort.experimental.commands.registerCreateCommand(
     data,
-    createCommand
+    async (args: CommandFnArgs) => {
+      const cmd = await createCommand(args)
+
+      if (!cmd) {
+        return null
+      }
+
+      return isCommandProxy(cmd) ? cmd : Command(cmd);
+    }
   );
 }

--- a/modules/extensions/src/commands/index.ts
+++ b/modules/extensions/src/commands/index.ts
@@ -38,7 +38,12 @@ export type CommandsFn = (
 
 export type CreateCommand = (
   args: CommandFnArgs
-) => CommandProxy | Promise<CommandProxy> | CommandArgs | Promise<CommandArgs> | null;
+) =>
+  | CommandProxy
+  | Promise<CommandProxy>
+  | CommandArgs
+  | Promise<CommandArgs>
+  | null;
 
 export type Run = () => any;
 
@@ -174,6 +179,11 @@ export function Command(cmdArgs: CommandArgs): CommandProxy {
         // Compute subcommands
         let subCmds = await commands(args);
 
+        // While we expect commands() to return an array, we don't want to throw an error if it doesn't.
+        if (!subCmds || !Array.isArray(subCmds)) {
+          return proxy([]);
+        }
+
         const commandProxyArray: Array<CommandProxy> = subCmds.map((subCmd) => {
           // Subcommands can be either a CommandArgs or a CommandProxy.
           // If it's already a wrapped command, just return it.
@@ -228,7 +238,5 @@ export type CommandProxy =
         description?: string;
         icon?: string;
       };
-      commands?: (
-        args: CommandFnArgs
-      ) => Promise<Array<CommandProxy>>;
+      commands?: (args: CommandFnArgs) => Promise<Array<CommandProxy>>;
     } & ProxyMarked & { [CommandSymbol]: true });

--- a/modules/extensions/src/commands/index.ts
+++ b/modules/extensions/src/commands/index.ts
@@ -38,7 +38,7 @@ export type CommandsFn = (
 
 export type CreateCommand = (
   args: CommandFnArgs
-) => CommandProxy | Promise<CommandProxy> | CommandArgs | Promise<CommandArgs>;
+) => CommandProxy | Promise<CommandProxy> | CommandArgs | Promise<CommandArgs> | null;
 
 export type Run = () => any;
 
@@ -214,25 +214,21 @@ export function Command(cmdArgs: CommandArgs): CommandProxy {
 export type CommandProxy =
   | ({
       data: {
-        type: string;
+        type: "action";
         label: string;
         description?: string;
         icon?: string;
       };
       run?: Run;
-      commands?: (
-        args: CommandFnArgs
-      ) => Promise<Array<CommandProxy | CommandArgs>>;
     } & ProxyMarked & { [CommandSymbol]: true })
   | ({
       data: {
-        type: string;
+        type: "context";
         label: string;
         description?: string;
         icon?: string;
       };
-      run?: Run;
       commands?: (
         args: CommandFnArgs
-      ) => Promise<Array<CommandProxy | CommandArgs>>;
-    } & ProxyMarked & { [CommandSymbol]: true })[];
+      ) => Promise<Array<CommandProxy>>;
+    } & ProxyMarked & { [CommandSymbol]: true });

--- a/modules/extensions/src/commands/index.ts
+++ b/modules/extensions/src/commands/index.ts
@@ -145,7 +145,7 @@ export function isCommandProxy(cmd: object): cmd is CommandProxy {
 
 /**
  * This function validates a command and wraps it in a proxy so that it can be sent over the wire
- * 
+ *
  * It:
  * - Validates the command's arguments, separates serializable and non-serializable arguments
  * - Wraps the command in a proxy so that it can be sent over the wire
@@ -156,7 +156,7 @@ export function Command(cmdArgs: CommandArgs): CommandProxy {
   // If the command is already wrapped, just return it.
   // This is to prevent accidental double-wrapping
   if (isCommandProxy(cmdArgs)) {
-    throw new Error('Command is already wrapped')
+    throw new Error("Command is already wrapped");
   }
 
   // Validate the command's arguments

--- a/modules/extensions/src/types/index.ts
+++ b/modules/extensions/src/types/index.ts
@@ -217,7 +217,7 @@ export type ExperimentalAPI = {
         commandId: string;
         contributions: Array<string>;
       },
-      create: CreateCommand
+      create: (createArgs: CommandFnArgs) => Promise<CommandProxy | null>
     ) => void;
   };
 };


### PR DESCRIPTION
## Why?

Currently, we make you wrap every single command, even nested ones. The invocation looks like

```javascript
await replit.experimental.commands.add(
  { id: "hey", contributions: ["commandbar"] },
  Command({
    label: "hey",
    description: "hey commands",
    commands: () => {
      return [
        Command({
          label: "hello",
          description: "says hello",
          run: () => console.log("hello"),
        }),
        Command({
          label: "hola",
          description: "says hola",
          run: () => console.log("hola"),
        }),
      ];
    },
  }),
);

```

It would be nice to not have to wrap things in Command(). The client library can simply do it for you.

```javascript
await replit.experimental.commands.add(
  { id: "hey", contributions: ["commandbar"] },
  {
    label: "hey",
    description: "hey commands",
    commands: () => {
      return [
        {
          label: "hello",
          description: "says hello",
          run: () => console.log("hello"),
        },
        {
          label: "hola",
          description: "says hola",
          run: () => console.log("hola"),
        },
      ];
    },
  },
);
```

I didn't remove Command() because I think it's actually a good pattern for composing larger commands. Also, backwards compatibility!

```javascript
let hola = Command({
  label: "hola",
  description: "says hola",
  run: () => console.log("hola"),
});

let hello = Command({
  label: "hello",
  description: "says hello",
  run: () => console.log("hello"),
});

await replit.experimental.commands.add(
  { id: "hey", contributions: ["commandbar"] },
  {
    label: "hey",
    description: "hey commands",
    commands: () => {
      return [hola, hello];
    },
  },
);
```

## What changed

- Now the `add`, and the old `register` / `registerCreate` methods all accept raw objects in addition to the wrapped `Command(...)`. When you don't wrap your command objects, we do it for you
- To accomplish this, we attach a `{[CommandSymbol]: true}` once we wrap, just to make sure we're not doing it twice
- Beyond that, not a lot has changed. We had to update a bunch of types to reflect this new world

## Test plan

- clone this repo as a repl
- hit run
- load locally via extensions devtools
- now open the chrome dev tools console, and paste in the second code snippet. you should now see a command called `hey` in the commandbar, which returns `hello` and `hola`
